### PR TITLE
Feat/database migrations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.1.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<version>3.5.3</version>
 	</parent>
 	<groupId>com.jhonatan</groupId>
 	<artifactId>ecommerce-api</artifactId>
@@ -66,6 +65,14 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,15 @@
 spring.application.name=ecommerce-api
 
-spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/ecommerce_db}
-spring.datasource.username=${DB_USERNAME:postgres}
-spring.datasource.password=${DB_PASSWORD:postgres}
+spring.datasource.url=jdbc:postgresql://localhost:5432/ecommerce_db
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.jpa.open-in-view=false

--- a/src/main/resources/db/migration/V1__create_table_usuarios.sql
+++ b/src/main/resources/db/migration/V1__create_table_usuarios.sql
@@ -1,0 +1,9 @@
+CREATE TABLE usuarios
+(
+    id    bigserial primary key,
+    nome  varchar(100) not null,
+    email varchar(250) not null,
+    senha varchar(250) not null,
+    tipo  varchar(100) not null,
+    ativo boolean      not null default true
+);

--- a/src/main/resources/db/migration/V2__create_table_categorias.sql
+++ b/src/main/resources/db/migration/V2__create_table_categorias.sql
@@ -1,0 +1,7 @@
+CREATE TABLE categorias
+(
+    id        bigserial primary key,
+    nome      varchar(100) not null,
+    descricao varchar(300) not null
+
+);

--- a/src/main/resources/db/migration/V3__create_table_produtos.sql
+++ b/src/main/resources/db/migration/V3__create_table_produtos.sql
@@ -1,0 +1,12 @@
+CREATE TABLE produtos
+(
+    id           bigserial PRIMARY KEY,
+    nome         VARCHAR(100)   NOT NULL,
+    descricao    VARCHAR(300)   NOT NULL,
+    preco        NUMERIC(10, 2) NOT NULL,
+    estoque      INTEGER        NOT NULL,
+    categoria_id BIGINT         NOT NULL,
+
+    CONSTRAINT fk_produto_categoria_id
+        FOREIGN KEY (categoria_id) REFERENCES categorias (id)
+);

--- a/src/main/resources/db/migration/V4__create_table_pedidos.sql
+++ b/src/main/resources/db/migration/V4__create_table_pedidos.sql
@@ -1,0 +1,11 @@
+CREATE TABLE pedidos
+(
+    id                 bigserial PRIMARY KEY,
+    usuario_id         BIGINT         NOT NULL,
+    data_pedido        TIMESTAMP      NOT NULL,
+    status_pedido      VARCHAR(100)   NOT NULL,
+    valor_total_pedido NUMERIC(10, 2) NOT NULL,
+
+    CONSTRAINT fk_pedido_usuario_id
+        FOREIGN KEY (usuario_id) REFERENCES usuarios (id)
+);

--- a/src/main/resources/db/migration/V5__create_table_itens_pedido.sql
+++ b/src/main/resources/db/migration/V5__create_table_itens_pedido.sql
@@ -1,0 +1,14 @@
+CREATE TABLE itens_pedido
+(
+    id             bigserial PRIMARY KEY,
+    pedido_id      BIGINT         NOT NULL,
+    produto_id     BIGINT         NOT NULL,
+    quantidade     INTEGER        NOT NULL CHECK (quantidade > 0),
+    preco_unitario NUMERIC(10, 2) NOT NULL,
+
+    CONSTRAINT fk_itens_pedido_pedido_id
+        FOREIGN KEY (pedido_id) REFERENCES pedidos (id),
+
+    CONSTRAINT fk_pedido_produto_id
+        FOREIGN KEY (produto_id) REFERENCES produtos (id)
+);


### PR DESCRIPTION
Atualização do Spring Boot e criação das migrations iniciais

Motivo

A versão 4.1.0 do Spring Boot não estava reconhecendo o Flyway, então precisei voltar para a 3.5.3 para resolver o problema.

O que foi feito:

1. Adicionei a dependência do Flyway no projeto.
2. Criei as migrations iniciais para as seguintes tabelas:
- usuarios
- categorias
- produtos
- pedidos
- itens_pedido