### PR TITLE
feat: implementa login com JWT e regras de autorização por rota

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
@@ -1,14 +1,36 @@
 package com.jhonatan.ecommerce_api.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import com.jhonatan.ecommerce_api.dto.LoginRequest;
+import com.jhonatan.ecommerce_api.dto.TokenResponseDTO;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import com.jhonatan.ecommerce_api.security.JwtService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/login")
+@RequestMapping("/api/v1/auth")
 public class AuthController {
-    @GetMapping
-    public String login() {
-        return "login";
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtService tokenService;
+
+    public AuthController(AuthenticationManager authenticationManager, JwtService tokenService) {
+        this.authenticationManager = authenticationManager;
+        this.tokenService = tokenService;
+    }
+
+
+    @PostMapping("/login")
+    public ResponseEntity efetuarLogin(@RequestBody @Valid LoginRequest loginRequest) {
+        var autenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.senha());
+        var authentication = authenticationManager.authenticate(autenticationToken);
+        var tokenJwt = tokenService.generateToken((Usuario) authentication.getPrincipal());
+        return ResponseEntity.ok(new TokenResponseDTO(tokenJwt));
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/LoginRequest.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.jhonatan.ecommerce_api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        String senha) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/TokenResponseDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/TokenResponseDTO.java
@@ -1,0 +1,4 @@
+package com.jhonatan.ecommerce_api.dto;
+
+public record TokenResponseDTO (String accessToken){
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 
 @Service

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -2,46 +2,66 @@ package com.jhonatan.ecommerce_api.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfigurations {
+    private final SecurityFilter securityFilter;
+
+    public SecurityConfigurations(SecurityFilter securityFilter) {
+        this.securityFilter = securityFilter;
+    }
+
 
     @Bean
-    public UserDetailsService dadosDoUsuarioCadastrados() {
-        UserDetails usuario1 = User.builder()
-                .username("jhon@gmail.com")
-                .password("{noop}12345678")
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // 1. Público — cadastro e login
+                        .requestMatchers(HttpMethod.POST, "/api/v1/usuarios").permitAll()
+                        .requestMatchers("/api/v1/auth/login").permitAll()
+
+                        // 1. Público — vitrine (catálogo)
+                        .requestMatchers(HttpMethod.GET, "/api/v1/produtos", "/api/v1/produtos/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/categorias", "/api/v1/categorias/**").permitAll()
+
+                        // 3. Só ADMIN
+                        .requestMatchers(HttpMethod.GET, "/api/v1/usuarios").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/usuarios/*/activate").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/usuarios/*/deactivate").hasRole("ADMIN")
+
+                        // 4. ADMIN ou VENDEDOR — gestão de catálogo
+                        .requestMatchers(HttpMethod.POST, "/api/v1/produtos").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/produtos/**").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/categorias").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/categorias/**").hasAnyRole("ADMIN", "VENDEDOR")
+
+                        // 5. Fallback — qualquer coisa não listada acima exige login
+                        .anyRequest().authenticated()
+                ).addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
-        UserDetails usuario2 = User.builder()
-                .username("jhon2@gmail.com")
-                .password("{noop}112345678")
-                .build();
-        return new InMemoryUserDetailsManager(usuario1, usuario2);
+    }
+
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     @Bean
-    public SecurityFilterChain filtroDeSeguranca(HttpSecurity http) throws Exception {
-        return http.authorizeHttpRequests(req -> {
-            req.requestMatchers("/login").permitAll();
-            req.anyRequest().authenticated();
-        }).formLogin(form -> form.loginPage("/login")
-                .defaultSuccessUrl("/categories")
-                .permitAll())
-                .logout(logout -> logout.logoutSuccessUrl("/login?logout")
-                        .permitAll())
-                .rememberMe(rememberMe -> rememberMe.key("lembrarDeMim")
-                        .tokenValiditySeconds(36000)
-                )
-                .csrf(Customizer.withDefaults())
-                .build();
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityFilter.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityFilter.java
@@ -1,4 +1,50 @@
 package com.jhonatan.ecommerce_api.security;
 
-public class SecurityFilter {
+import com.jhonatan.ecommerce_api.exception.EmailNotFoundException;
+import com.jhonatan.ecommerce_api.repository.UsuarioRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class SecurityFilter extends OncePerRequestFilter {
+    private final JwtService jwtService;
+    private final UsuarioRepository usuarioRepository;
+
+    public SecurityFilter(JwtService jwtService, UsuarioRepository usuarioRepository) {
+        this.jwtService = jwtService;
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    // Intercepta todas as requisições HTTP, extrai o JWT do cabeçalho Authorization
+    // e, caso o token seja válido, autentica o usuário no contexto de segurança do Spring.
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String tokenJWT = recuperarToken(request);
+
+        if(tokenJWT != null) {
+            String email = jwtService.getSubject(tokenJWT);
+            var usuario = usuarioRepository.findByEmailIgnoreCase(email)
+                    .orElseThrow(() -> new EmailNotFoundException("Usuário não encontrado"));
+            var authentication = new UsernamePasswordAuthenticationToken(usuario, null, usuario.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String recuperarToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            return null;
+        }
+        return authorizationHeader.substring(7);
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,5 @@ spring.flyway.locations=classpath:db/migration
 spring.jpa.open-in-view=false
 
 api.security.token.secret=${JWT_SECRET}
+
+logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
## feat: implementa login com JWT e regras de autorização por rota

Fecha o fluxo de autenticação: cadastro → login → token JWT válido, com autorização configurada por rota.

**O que foi feito**
- `SecurityFilter` reescrito para validar o JWT e autenticar o usuário a cada requisição
- `SecurityConfigurations` com regras de acesso por rota: público, autenticado e por cargo (ADMIN/VENDEDOR)
- Beans de `AuthenticationManager` e `PasswordEncoder`
- DTOs `LoginRequest` e `TokenResponseDTO`
- `AuthController` com o endpoint `POST /api/v1/auth/login` funcional

**Próximos passos**
Confirmação de conta por e-mail e recuperação de senha.