### PR TITLE
feat: configura envio de e-mail e cria tabela de tokens de confirmação

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-database-postgresql</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,14 @@ spring.jpa.open-in-view=false
 api.security.token.secret=${JWT_SECRET}
 
 logging.level.org.springframework.security=DEBUG
+
+#Configurações de email.
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${EMAIL}
+
+spring.mail.password=${GOOGLE_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+app.frontend.url=http://localhost:4200

--- a/src/main/resources/db/migration/V6__create_table_account_confirmation_tokens.sql
+++ b/src/main/resources/db/migration/V6__create_table_account_confirmation_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE account_confirmation_tokens
+(
+    id         BIGSERIAL PRIMARY KEY,
+    token      VARCHAR(255) NOT NULL UNIQUE,
+    usuario_id BIGINT       NOT NULL,
+    expires_at TIMESTAMP    NOT NULL,
+    usado      BOOLEAN      NOT NULL DEFAULT FALSE,
+    CONSTRAINT fk_act_usuario_id
+        FOREIGN KEY (usuario_id)
+            REFERENCES usuarios (id)
+            ON DELETE CASCADE
+);
+
+CREATE INDEX idx_act_usuario_id ON account_confirmation_tokens (usuario_id);


### PR DESCRIPTION
## Configura envio de e-mail e cria tabela de tokens de confirmação

**O que foi feito**
- Adiciona a dependência `spring-boot-starter-mail`
- Configura SMTP no `application.properties` via variáveis de ambiente (`EMAIL`, `GOOGLE_PASSWORD`)
- Cria a migration `V6__create_table_account_confirmation_tokens.sql`, com índice em `usuario_id` para consultas futuras de tokens por usuário
