### PR TITLE
feat: cria entidade e repository do token de confirmação de conta

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/model/TokenConfirmacaoConta.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/TokenConfirmacaoConta.java
@@ -1,0 +1,53 @@
+package com.jhonatan.ecommerce_api.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "account_confirmation_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenConfirmacaoConta {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private boolean usado;
+
+    public TokenConfirmacaoConta(Usuario usuario) {
+        validarUsuario(usuario);
+        this.usuario = usuario;
+        this.token = UUID.randomUUID().toString();
+        this.expiresAt = LocalDateTime.now().plusHours(24);
+        this.usado = false;
+    }
+
+    public boolean isValido() {
+        return !this.usado && LocalDateTime.now().isBefore(this.expiresAt);
+    }
+
+    public void marcarComoUsado() {
+        this.usado = true;
+    }
+
+    private void validarUsuario(Usuario usuario) {
+        if (usuario == null) {
+            throw new IllegalArgumentException("Usuário é obrigatório para gerar o token.");
+        }
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/repository/TokenConfirmacaoContaRepository.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/repository/TokenConfirmacaoContaRepository.java
@@ -1,0 +1,10 @@
+package com.jhonatan.ecommerce_api.repository;
+
+import com.jhonatan.ecommerce_api.model.TokenConfirmacaoConta;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenConfirmacaoContaRepository extends JpaRepository<TokenConfirmacaoConta, Long> {
+    Optional<TokenConfirmacaoConta> findByToken(String token);
+}


### PR DESCRIPTION
## Cria entidade e repository do token de confirmação de conta

**O que foi feito**
- Cria a entidade `TokenConfirmacaoConta`, seguindo o padrão de domínio rico já usado em `Usuario`: o construtor gera o token e a expiração (24h) internamente, e a validade é resolvida por `isValido()`
- Cria `TokenConfirmacaoContaRepository`, com `findByToken` para localizar o registro na hora da confirmação