### PR TITLE
fix: corrige erro de build e ajusta cadastro para nascer inativo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/jhonatan/ecommerce_api/mapper/UsuarioMapper.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/mapper/UsuarioMapper.java
@@ -13,13 +13,17 @@ public class UsuarioMapper {
     public UsuarioMapper(PasswordEncoder passwordEncoder) {
         this.passwordEncoder = passwordEncoder;
     }
-    public Usuario toEntity(UsuarioRequestDTO dto) {
-        return new Usuario(
+    public Usuario toEntity(UsuarioRequestDTO dto, boolean ativo) {
+        Usuario usuario = new Usuario(
                 dto.nome(),
                 dto.email(),
                 dto.senha(),
                 dto.tipo()
         );
+        if (!ativo) {
+            usuario.inativar();
+        }
+        return usuario;
     }
 
     public UsuarioResponseDTO toDTO(Usuario usuario) {

--- a/src/main/java/com/jhonatan/ecommerce_api/service/UsuarioService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/UsuarioService.java
@@ -32,7 +32,7 @@ public class UsuarioService {
         if(usuarioRepository.existsByEmail(dto.email())){
             throw new EmailAlreadyExistsException("Email já está cadastrado!");
         }
-        Usuario usuario = usuarioMapper.toEntity(dto);
+        Usuario usuario = usuarioMapper.toEntity(dto, false);
         usuario.alterarSenha(passwordEncoder.encode(dto.senha()));
         usuario = usuarioRepository.save(usuario);
         return usuarioMapper.toDTO(usuario);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ api.security.token.secret=${JWT_SECRET}
 
 logging.level.org.springframework.security=DEBUG
 
-#Configurações de email.
+#Configuracoes de email.
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=${EMAIL}


### PR DESCRIPTION

## Corrige erro de build no CI e ajusta cadastro para nascer inativo

**O que foi feito**
- Corrige um erro no build automático (CI) que acontecia por causa dos acentos no `application.properties`  o arquivo estava sendo salvo de um jeito que o servidor de build não conseguia ler corretamente
- Ajusta `UsuarioMapper.toEntity` para receber um parâmetro `ativo`, usando o método `inativar()` quando necessário
- Ajusta `UsuarioService.create()` para que todo cadastro feito pela API sempre nasça inativo, aguardando confirmação de e-mail essa decisão fica só dentro da service, sem expor isso pro controller
