### PR TITLE
feat(auth): implementa recuperação de senha via token por e-mail

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
@@ -2,9 +2,12 @@ package com.jhonatan.ecommerce_api.controller;
 
 import com.jhonatan.ecommerce_api.dto.LoginRequest;
 import com.jhonatan.ecommerce_api.dto.TokenResponseDTO;
+import com.jhonatan.ecommerce_api.dto.senha.NovaSenhaRequestDTO;
+import com.jhonatan.ecommerce_api.dto.senha.SolicitarRecuperacaoSenhaDTO;
 import com.jhonatan.ecommerce_api.model.Usuario;
 import com.jhonatan.ecommerce_api.security.JwtService;
 import com.jhonatan.ecommerce_api.service.ContaConfirmacaoService;
+import com.jhonatan.ecommerce_api.service.ResetaSenhaService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -17,11 +20,13 @@ public class AuthController {
     private final AuthenticationManager authenticationManager;
     private final JwtService tokenService;
     private final ContaConfirmacaoService contaConfirmacaoService;
+    private final ResetaSenhaService resetaSenhaService;
 
-    public AuthController(AuthenticationManager authenticationManager, JwtService tokenService, ContaConfirmacaoService contaConfirmacaoService) {
+    public AuthController(AuthenticationManager authenticationManager, JwtService tokenService, ContaConfirmacaoService contaConfirmacaoService, ResetaSenhaService resetaSenhaService) {
         this.authenticationManager = authenticationManager;
         this.tokenService = tokenService;
         this.contaConfirmacaoService = contaConfirmacaoService;
+        this.resetaSenhaService = resetaSenhaService;
     }
 
     @PostMapping("/login")
@@ -36,5 +41,17 @@ public class AuthController {
     public ResponseEntity<String> efetuarConta(@RequestParam String token) {
         contaConfirmacaoService.confirmarConta(token);
         return ResponseEntity.ok("Conta confirmada com sucesso! Você já pode fazer login.");
+    }
+
+    @PostMapping("/esqueci-senha")
+    public ResponseEntity<String> solicitarResetSenha(@RequestBody @Valid SolicitarRecuperacaoSenhaDTO dto) {
+        resetaSenhaService.solicitarRecuperacao(dto.email());
+        return ResponseEntity.ok("Se o e-mail existir em nossa base, você receberá instruções para redefinir sua senha.");
+    }
+
+    @PostMapping("/resetar-senha")
+    public ResponseEntity<String> resetarSenha(@RequestBody @Valid NovaSenhaRequestDTO dto) {
+        resetaSenhaService.redefinirSenha(dto.token(), dto.novaSenha());
+        return ResponseEntity.ok("Senha redefinida com sucesso! Você já pode fazer login.");
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/senha/NovaSenhaRequestDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/senha/NovaSenhaRequestDTO.java
@@ -1,0 +1,14 @@
+package com.jhonatan.ecommerce_api.dto.senha;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NovaSenhaRequestDTO(
+        @NotBlank(message = "Token é obrigatório")
+        String token,
+
+        @NotBlank(message = "Nova senha é obrigatória")
+        @Size(min = 6, message = "A senha deve ter no mínimo 6 caracteres")
+        String novaSenha
+) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/senha/SolicitarRecuperacaoSenhaDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/senha/SolicitarRecuperacaoSenhaDTO.java
@@ -1,0 +1,10 @@
+package com.jhonatan.ecommerce_api.dto.senha;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SolicitarRecuperacaoSenhaDTO(
+        @NotBlank(message = "Email é obrigatório")
+        @Email(message = "Formato de email inválido")
+        String email) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/UsuarioRequestDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/UsuarioRequestDTO.java
@@ -4,6 +4,7 @@ import com.jhonatan.ecommerce_api.enums.TipoUsuario;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record UsuarioRequestDTO(
         @NotBlank
@@ -12,6 +13,7 @@ public record UsuarioRequestDTO(
         @NotBlank
         String email,
         @NotBlank
+        @Size(min = 6, message = "A senha deve ter no mínimo 6 caracteres")
         String senha,
         @NotNull
         TipoUsuario tipo

--- a/src/main/java/com/jhonatan/ecommerce_api/model/TokenResetSenha.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/TokenResetSenha.java
@@ -1,0 +1,52 @@
+package com.jhonatan.ecommerce_api.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "password_reset_tokens")
+@Getter
+public class TokenResetSenha {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean usado;
+
+    public TokenResetSenha() {}
+
+    public TokenResetSenha(String token, Usuario usuario) {
+        validarUsuario(usuario);
+        this.token = token;
+        this.usuario = usuario;
+        this.expiresAt = LocalDateTime.now().plusMinutes(30);
+        this.usado = false;
+    }
+    private void validarUsuario(Usuario usuario) {
+        if (usuario == null) {
+            throw new IllegalArgumentException("Usuário é obrigatório para gerar o token.");
+        }
+    }
+
+    public void marcarComoUsado() {
+        this.usado = true;
+    }
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,14 @@
+package com.jhonatan.ecommerce_api.repository;
+
+import com.jhonatan.ecommerce_api.model.TokenResetSenha;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<TokenResetSenha, Long> {
+    Optional<TokenResetSenha> findByToken(String token);
+    // Deleta todos os tokens de um usuário antes de criar um novo.
+    // Evita acúmulo de tokens inválidos no banco.
+    void deleteAllByUsuario(Usuario usuario);
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -29,9 +29,11 @@ public class SecurityConfigurations {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 1. Público — cadastro e login
-                        .requestMatchers(HttpMethod.GET, "/api/v1/auth/confirmar-conta").permitAll()
+                        .requestMatchers("/api/v1/auth/confirmar-conta").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/usuarios").permitAll()
                         .requestMatchers("/api/v1/auth/login").permitAll()
+                        .requestMatchers("/api/v1/auth/esqueci-senha").permitAll()
+                        .requestMatchers("/api/v1/auth/resetar-senha").permitAll()
 
                         // 1. Público — vitrine (catálogo)
                         .requestMatchers(HttpMethod.GET, "/api/v1/produtos", "/api/v1/produtos/**").permitAll()

--- a/src/main/java/com/jhonatan/ecommerce_api/service/EmailService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/EmailService.java
@@ -17,6 +17,29 @@ public class EmailService {
         this.mailSender = mailSender;
     }
 
+    public void enviarEmailDeRecuperacao(String destinatario, String token) {
+
+        // Monta o link que o usuário vai clicar no email.
+        // O frontend lê o ?token= da URL e exibe o formulário de nova senha.
+        String link = frontendUrl + "/reset-senha?token=" + token;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(destinatario);
+        message.setSubject("Recuperação de senha");
+        message.setText("""
+                Olá!
+
+                Recebemos uma solicitação para redefinir a senha da sua conta.
+                Clique no link abaixo para continuar (válido por 30 minutos):
+
+                %s
+
+                Se você não solicitou a recuperação de senha, ignore este email.
+                Sua senha permanece a mesma.
+                """.formatted(link));
+
+        mailSender.send(message);
+    }
 
     public void enviarEmailDeConfirmacao(String destinatario, String token) {
         String link = frontendUrl + "/confirmar-conta?token=" + token;

--- a/src/main/java/com/jhonatan/ecommerce_api/service/ResetaSenhaService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/ResetaSenhaService.java
@@ -1,0 +1,59 @@
+package com.jhonatan.ecommerce_api.service;
+
+import com.jhonatan.ecommerce_api.exception.TokenInvalidoException;
+import com.jhonatan.ecommerce_api.model.TokenResetSenha;
+import com.jhonatan.ecommerce_api.repository.PasswordResetTokenRepository;
+import com.jhonatan.ecommerce_api.repository.UsuarioRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class ResetaSenhaService {
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordResetTokenRepository tokenRepository;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
+
+    public ResetaSenhaService(UsuarioRepository usuarioRepository, PasswordResetTokenRepository tokenRepository, EmailService emailService, PasswordEncoder passwordEncoder) {
+        this.usuarioRepository = usuarioRepository;
+        this.tokenRepository = tokenRepository;
+        this.emailService = emailService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+
+    @Transactional
+    public void solicitarRecuperacao(String email) {
+        // o IfPresente é pra se o email não existir retornar a resposta da mesma forma
+        // assim evita que alguém descubra quais emails estão cadastrados.
+        usuarioRepository.findByEmailIgnoreCase(email).ifPresent(usuario -> {
+            // Remove tokens anteriores do mesmo usuário.
+            // Garante que apenas um link de reset esteja ativo por vez.
+            tokenRepository.deleteAllByUsuario(usuario);
+            String token = UUID.randomUUID().toString();
+            tokenRepository.save(new TokenResetSenha(token, usuario));
+            emailService.enviarEmailDeRecuperacao(email, token);
+        });
+    }
+
+    @Transactional
+    public void redefinirSenha(String token, String novaSenha) {
+        TokenResetSenha resetToken = tokenRepository.findByToken(token)
+                .orElseThrow(() -> new TokenInvalidoException("Token inválido ou inexistente."));
+        if (resetToken.isUsado()) {
+            throw new TokenInvalidoException("Este link já foi utilizado. Solicite um novo.");
+        }
+        if (resetToken.isExpired()) {
+            throw new TokenInvalidoException("Token expirado. Solicite um novo link de recuperação.");
+        }
+
+        var usuario = resetToken.getUsuario();
+        usuario.alterarSenha(passwordEncoder.encode(novaSenha));
+        usuarioRepository.save(usuario);
+        resetToken.marcarComoUsado();
+        tokenRepository.save(resetToken);
+    }
+}

--- a/src/main/resources/db/migration/V7__create_table_password_reset_tokens.sql
+++ b/src/main/resources/db/migration/V7__create_table_password_reset_tokens.sql
@@ -1,0 +1,11 @@
+CREATE TABLE password_reset_tokens
+(
+    id         BIGSERIAL PRIMARY KEY,
+    token      VARCHAR(255) NOT NULL UNIQUE,
+    usuario_id BIGINT       NOT NULL,
+    expires_at TIMESTAMP    NOT NULL,
+    usado      BOOLEAN      NOT NULL DEFAULT FALSE,
+    CONSTRAINT fk_prt_user
+        FOREIGN KEY (usuario_id)
+            REFERENCES usuarios (id)
+);


### PR DESCRIPTION
## O que este PR faz

Implementa o fluxo de recuperação de senha ("esqueci minha senha"),
fechando a Fase 2 do projeto (autenticação e acesso à conta).

## Como funciona

1. Usuário solicita reset informando o e-mail (`POST /esqueci-senha`)
2. Sistema gera um token de uso único, válido por 30 minutos, e
   envia por e-mail com o link de redefinição
3. Usuário envia o token + nova senha (`POST /resetar-senha`)
4. Sistema valida o token (existe? não expirou? não foi usado?) e
   atualiza a senha

## Decisões de design

- **Resposta genérica na solicitação**: independente de o e-mail
  existir ou não na base, a resposta é sempre a mesma. Evita que o
  endpoint seja usado para descobrir quais e-mails estão cadastrados.
- **Token de uso único, curto (30min)**: mais restritivo que o token
  de confirmação de conta (24h), já que troca de senha é uma ação
  mais sensível.
- **Reaproveita o padrão do `ContaConfirmacaoService`**: mesma
  estrutura de entidade/token, mantendo consistência no código.

## Testes realizados

- [x] Migration `V7` aplicada sem erros
- [x] Solicitação com e-mail existente → e-mail recebido com token
- [x] Reset com token válido → senha alterada e login funciona
- [x] Login com senha antiga falha após o reset
- [x] Token já usado → erro apropriado
- [x] Token inválido/inexistente → erro apropriado