### PR TITLE
feat(auth): adiciona refresh token e reenvio de confirmação de conta

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
@@ -1,12 +1,16 @@
 package com.jhonatan.ecommerce_api.controller;
 
-import com.jhonatan.ecommerce_api.dto.LoginRequest;
+import com.jhonatan.ecommerce_api.dto.login.LoginRequest;
+import com.jhonatan.ecommerce_api.dto.login.ReenviarConfirmacaoDTO;
+import com.jhonatan.ecommerce_api.dto.RefreshRequestDTO;
 import com.jhonatan.ecommerce_api.dto.TokenResponseDTO;
 import com.jhonatan.ecommerce_api.dto.senha.NovaSenhaRequestDTO;
 import com.jhonatan.ecommerce_api.dto.senha.SolicitarRecuperacaoSenhaDTO;
+import com.jhonatan.ecommerce_api.model.RefreshToken;
 import com.jhonatan.ecommerce_api.model.Usuario;
 import com.jhonatan.ecommerce_api.security.JwtService;
 import com.jhonatan.ecommerce_api.service.ContaConfirmacaoService;
+import com.jhonatan.ecommerce_api.service.RefreshTokenService;
 import com.jhonatan.ecommerce_api.service.ResetaSenhaService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -21,27 +25,37 @@ public class AuthController {
     private final JwtService tokenService;
     private final ContaConfirmacaoService contaConfirmacaoService;
     private final ResetaSenhaService resetaSenhaService;
+    private final RefreshTokenService refreshTokenService;
 
-    public AuthController(AuthenticationManager authenticationManager, JwtService tokenService, ContaConfirmacaoService contaConfirmacaoService, ResetaSenhaService resetaSenhaService) {
+    public AuthController(AuthenticationManager authenticationManager, JwtService tokenService,
+                          ContaConfirmacaoService contaConfirmacaoService, ResetaSenhaService resetaSenhaService,
+                          RefreshTokenService refreshTokenService) {
         this.authenticationManager = authenticationManager;
         this.tokenService = tokenService;
         this.contaConfirmacaoService = contaConfirmacaoService;
         this.resetaSenhaService = resetaSenhaService;
+        this.refreshTokenService = refreshTokenService;
     }
 
     @PostMapping("/login")
-    public ResponseEntity efetuarLogin(@RequestBody @Valid LoginRequest loginRequest) {
+    public ResponseEntity<TokenResponseDTO> efetuarLogin(@RequestBody @Valid LoginRequest loginRequest) {
         var autenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.senha());
         var authentication = authenticationManager.authenticate(autenticationToken);
-        String tokenJwt = tokenService.generateToken((Usuario) authentication.getPrincipal());
-        return ResponseEntity.ok(new TokenResponseDTO(tokenJwt));
+        var usuario = (Usuario) authentication.getPrincipal();
+        String accessToken = tokenService.generateToken(usuario);
+        RefreshToken refreshToken = refreshTokenService.gerarNovoToken(usuario);
+        return ResponseEntity.ok(new TokenResponseDTO(accessToken, refreshToken.getToken()));
     }
+
+
 
     @GetMapping("/confirmar-conta")
     public ResponseEntity<String> efetuarConta(@RequestParam String token) {
         contaConfirmacaoService.confirmarConta(token);
         return ResponseEntity.ok("Conta confirmada com sucesso! Você já pode fazer login.");
     }
+
+
 
     @PostMapping("/esqueci-senha")
     public ResponseEntity<String> solicitarResetSenha(@RequestBody @Valid SolicitarRecuperacaoSenhaDTO dto) {
@@ -53,5 +67,16 @@ public class AuthController {
     public ResponseEntity<String> resetarSenha(@RequestBody @Valid NovaSenhaRequestDTO dto) {
         resetaSenhaService.redefinirSenha(dto.token(), dto.novaSenha());
         return ResponseEntity.ok("Senha redefinida com sucesso! Você já pode fazer login.");
+    }
+
+    @PostMapping("/reenviar-confirmacao")
+    public ResponseEntity<String> reenviarConfirmacao(@RequestBody @Valid ReenviarConfirmacaoDTO dto) {
+        contaConfirmacaoService.reenviarConfirmacao(dto.email());
+        return ResponseEntity.ok("Se o e-mail existir em nossa base e a conta ainda não tiver sido confirmada, você receberá um novo link.");
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponseDTO> renovarToken(@RequestBody @Valid RefreshRequestDTO dto) {
+        return ResponseEntity.ok(refreshTokenService.refresh(dto.refreshToken()));
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/RefreshRequestDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/RefreshRequestDTO.java
@@ -1,0 +1,9 @@
+package com.jhonatan.ecommerce_api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequestDTO(
+        @NotBlank(message = "É necessário fazer login novamente!")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/TokenResponseDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/TokenResponseDTO.java
@@ -1,4 +1,4 @@
 package com.jhonatan.ecommerce_api.dto;
 
-public record TokenResponseDTO (String accessToken){
+public record TokenResponseDTO (String accessToken, String refreshToken){
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/login/LoginRequest.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/login/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.jhonatan.ecommerce_api.dto;
+package com.jhonatan.ecommerce_api.dto.login;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/login/ReenviarConfirmacaoDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/login/ReenviarConfirmacaoDTO.java
@@ -1,0 +1,10 @@
+package com.jhonatan.ecommerce_api.dto.login;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ReenviarConfirmacaoDTO(
+        @NotBlank(message = "Email é obrigatório")
+        @Email(message = "Formato de email inválido")
+        String email) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/model/RefreshToken.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/RefreshToken.java
@@ -1,0 +1,48 @@
+package com.jhonatan.ecommerce_api.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean revogado;
+
+    public RefreshToken(Usuario usuario) {
+        this.token = UUID.randomUUID().toString();
+        this.usuario = usuario;
+        this.expiresAt = LocalDateTime.now().plusDays(7);
+        this.revogado = false;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+
+    public void revogar() {
+        this.revogado = true;
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.jhonatan.ecommerce_api.repository;
+
+import com.jhonatan.ecommerce_api.model.RefreshToken;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+
+    // Sessão única: apaga qualquer refresh token anterior do usuário
+    // antes de emitir um novo (no login ou no refresh).
+    void deleteAllByUsuario(Usuario usuario);
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
@@ -58,7 +58,11 @@ public class JwtService {
     }
 
 
+//    private Instant dataExpiracao() {
+//        return LocalDateTime.now().plusDays(1).toInstant(ZoneOffset.UTC);
+//    }
+
     private Instant dataExpiracao() {
-        return LocalDateTime.now().plusDays(1).toInstant(ZoneOffset.UTC);
+        return LocalDateTime.now().plusMinutes(15).toInstant(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -29,11 +29,15 @@ public class SecurityConfigurations {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 1. Público — cadastro e login
-                        .requestMatchers("/api/v1/auth/confirmar-conta").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/usuarios").permitAll()
-                        .requestMatchers("/api/v1/auth/login").permitAll()
-                        .requestMatchers("/api/v1/auth/esqueci-senha").permitAll()
-                        .requestMatchers("/api/v1/auth/resetar-senha").permitAll()
+
+                        .requestMatchers(
+                                "/api/v1/auth/login",
+                                "/api/v1/auth/resetar-senha",
+                                "/api/v1/auth/esqueci-senha",
+                                "/api/v1/auth/confirmar-conta",
+                                "/api/v1/auth/reenviar-confirmacao",
+                                "/api/v1/auth/refresh").permitAll()
 
                         // 1. Público — vitrine (catálogo)
                         .requestMatchers(HttpMethod.GET, "/api/v1/produtos", "/api/v1/produtos/**").permitAll()

--- a/src/main/java/com/jhonatan/ecommerce_api/service/ContaConfirmacaoService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/ContaConfirmacaoService.java
@@ -31,6 +31,15 @@ public class ContaConfirmacaoService {
     }
 
     @Transactional
+    public void reenviarConfirmacao(String email) {
+        usuarioRepository.findByEmailIgnoreCase(email).ifPresent(usuario -> {
+            if (!usuario.isAtivo()) {
+                enviarConfirmacao(usuario);
+            }
+        });
+    }
+
+    @Transactional
     public void confirmarConta(String token) {
         TokenConfirmacaoConta confirmacaoToken = tokenRepository.findByToken(token)
                 .orElseThrow(() -> new TokenInvalidoException("Token inválido ou inexistente."));

--- a/src/main/java/com/jhonatan/ecommerce_api/service/RefreshTokenService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/RefreshTokenService.java
@@ -1,0 +1,57 @@
+package com.jhonatan.ecommerce_api.service;
+
+import com.jhonatan.ecommerce_api.dto.TokenResponseDTO;
+import com.jhonatan.ecommerce_api.exception.TokenInvalidoException;
+import com.jhonatan.ecommerce_api.model.RefreshToken;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import com.jhonatan.ecommerce_api.repository.RefreshTokenRepository;
+import com.jhonatan.ecommerce_api.security.JwtService;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtService jwtService;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository, JwtService jwtService) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtService = jwtService;
+    }
+
+    // Chamado no login. Sessão única: qualquer refresh token anterior
+    // do usuário é apagado antes de emitir o novo.
+    @Transactional
+    public RefreshToken gerarNovoToken(Usuario usuario) {
+        refreshTokenRepository.deleteAllByUsuario(usuario);
+        return refreshTokenRepository.save(new RefreshToken(usuario));
+    }
+
+    // Chamado no /refresh. Rotação: valida o token recebido, gera um
+    // access token novo E um refresh token novo, revogando o antigo.
+    // Um refresh token só pode ser usado uma vez — reutilizar um já
+    // trocado cai no isRevogado() e é barrado.
+    @Transactional
+    public TokenResponseDTO refresh(String refreshTokenValue) {
+        RefreshToken tokenAtual = refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> new TokenInvalidoException("Refresh token inválido ou inexistente."));
+
+        if (tokenAtual.isRevogado()) {
+            throw new TokenInvalidoException("Refresh token revogado. Faça login novamente.");
+        }
+        if (tokenAtual.isExpired()) {
+            throw new TokenInvalidoException("Refresh token expirado. Faça login novamente.");
+        }
+
+        Usuario usuario = tokenAtual.getUsuario();
+
+        tokenAtual.revogar();
+        refreshTokenRepository.save(tokenAtual);
+
+        RefreshToken novoRefreshToken = refreshTokenRepository.save(new RefreshToken(usuario));
+        String novoAccessToken = jwtService.generateToken(usuario);
+
+        return new TokenResponseDTO(novoAccessToken, novoRefreshToken.getToken());
+    }
+}

--- a/src/main/resources/db/migration/V8__password_reset_tokens.sql
+++ b/src/main/resources/db/migration/V8__password_reset_tokens.sql
@@ -1,0 +1,11 @@
+CREATE TABLE refresh_tokens
+(
+    id         BIGSERIAL PRIMARY KEY,
+    token      VARCHAR(255) NOT NULL UNIQUE,
+    usuario_id BIGINT       NOT NULL,
+    expires_at TIMESTAMP    NOT NULL,
+    revogado   BOOLEAN      NOT NULL DEFAULT FALSE,
+    CONSTRAINT fk_rt_user
+        FOREIGN KEY (usuario_id)
+            REFERENCES usuarios (id)
+);


### PR DESCRIPTION
Adiciona refresh token no login: agora vem accessToken (15min) e
refreshToken (7 dias) na resposta. Endpoint novo /refresh troca o
refresh token por um par novo, e revoga o antigo, então cada
refresh token só serve uma vez. Login novo também derruba qualquer
sessão anterior do mesmo usuário.

Além disso, endpoint /reenviar-confirmacao pro caso do token de
confirmação de conta vencer antes do usuário confirmar.

Migration V8 (tabela refresh_tokens) já aplicada.

Testado manualmente: login devolvendo os dois tokens, refresh
gerando par novo e revogando o antigo, login novo invalidando
sessão anterior, reenvio de confirmação mandando e-mail novo.