### PR TITLE
fix(security): corrige escalonamento de privilégio no cadastro de usu…

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/controller/UsuarioController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/UsuarioController.java
@@ -1,5 +1,6 @@
 package com.jhonatan.ecommerce_api.controller;
 
+import com.jhonatan.ecommerce_api.dto.usuario.AlterarTipoDTO;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioRequestDTO;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioResponseDTO;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioUpdateDTO;
@@ -29,6 +30,7 @@ public class UsuarioController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or #id == authentication.principal.id")
     public ResponseEntity<UsuarioResponseDTO> update(@PathVariable Long id, @RequestBody @Valid UsuarioUpdateDTO dto) {
         UsuarioResponseDTO response = usuarioService.updateUser(id, dto);
         return ResponseEntity.ok(response);
@@ -57,5 +59,11 @@ public class UsuarioController {
     public ResponseEntity<Void> activate(@PathVariable Long id) {
         usuarioService.activate(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/tipo")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UsuarioResponseDTO> alterarTipo(@PathVariable Long id, @RequestBody @Valid AlterarTipoDTO dto) {
+        return ResponseEntity.ok(usuarioService.alterarTipo(id, dto.tipo()));
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/AlterarTipoDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/AlterarTipoDTO.java
@@ -1,0 +1,10 @@
+package com.jhonatan.ecommerce_api.dto.usuario;
+
+import com.jhonatan.ecommerce_api.enums.TipoUsuario;
+import jakarta.validation.constraints.NotNull;
+
+public record AlterarTipoDTO(
+        @NotNull(message = "Tipo é obrigatório")
+        TipoUsuario tipo
+) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/UsuarioRequestDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/UsuarioRequestDTO.java
@@ -1,9 +1,7 @@
 package com.jhonatan.ecommerce_api.dto.usuario;
 
-import com.jhonatan.ecommerce_api.enums.TipoUsuario;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record UsuarioRequestDTO(
@@ -14,8 +12,6 @@ public record UsuarioRequestDTO(
         String email,
         @NotBlank
         @Size(min = 6, message = "A senha deve ter no mínimo 6 caracteres")
-        String senha,
-        @NotNull
-        TipoUsuario tipo
+        String senha
 ) {
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/UsuarioUpdateDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/usuario/UsuarioUpdateDTO.java
@@ -5,7 +5,6 @@ import com.jhonatan.ecommerce_api.enums.TipoUsuario;
 public record UsuarioUpdateDTO(
         String nome,
         String email,
-        String senha,
-        TipoUsuario tipo
+        String senha
 ) {
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/mapper/UsuarioMapper.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/mapper/UsuarioMapper.java
@@ -3,6 +3,7 @@ package com.jhonatan.ecommerce_api.mapper;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioRequestDTO;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioResponseDTO;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioUpdateDTO;
+import com.jhonatan.ecommerce_api.enums.TipoUsuario;
 import com.jhonatan.ecommerce_api.model.Usuario;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -18,7 +19,8 @@ public class UsuarioMapper {
                 dto.nome(),
                 dto.email(),
                 passwordEncoder.encode(dto.senha()),
-                dto.tipo()
+                TipoUsuario.CLIENTE
+
         );
         if (!ativo) {
             usuario.inativar();
@@ -44,10 +46,6 @@ public class UsuarioMapper {
 
         if (dto.senha() != null) {
             entity.alterarSenha(passwordEncoder.encode(dto.senha()));
-        }
-
-        if (dto.tipo() != null) {
-            entity.alterarTipo(dto.tipo());
         }
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/model/Usuario.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/Usuario.java
@@ -52,6 +52,11 @@ public class Usuario implements UserDetails {
         this.ativo = true;
     }
 
+    public void definirTipo(TipoUsuario tipo) {
+        validarTipo(tipo);
+        this.tipo = tipo;
+    }
+
     public void alterarNome(String novoNome) {
         validarNome(novoNome);
         this.nome = novoNome;

--- a/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 @Service
 public class JwtService {
@@ -63,6 +64,6 @@ public class JwtService {
 //    }
 
     private Instant dataExpiracao() {
-        return LocalDateTime.now().plusMinutes(15).toInstant(ZoneOffset.UTC);
+        return Instant.now().plus(60, ChronoUnit.MINUTES);
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfigurations {
     private final SecurityFilter securityFilter;
 
@@ -39,7 +41,7 @@ public class SecurityConfigurations {
                                 "/api/v1/auth/reenviar-confirmacao",
                                 "/api/v1/auth/refresh").permitAll()
 
-                        // 1. Público — vitrine (catálogo)
+                        // 2. Público — vitrine (catálogo)
                         .requestMatchers(HttpMethod.GET, "/api/v1/produtos", "/api/v1/produtos/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/categorias", "/api/v1/categorias/**").permitAll()
 
@@ -47,6 +49,7 @@ public class SecurityConfigurations {
                         .requestMatchers(HttpMethod.GET, "/api/v1/usuarios").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/usuarios/*/activate").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/usuarios/*/deactivate").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/usuarios/*/tipo").hasRole("ADMIN")
 
                         // 4. ADMIN ou VENDEDOR — gestão de catálogo
                         .requestMatchers(HttpMethod.POST, "/api/v1/produtos").hasAnyRole("ADMIN", "VENDEDOR")

--- a/src/main/java/com/jhonatan/ecommerce_api/service/UsuarioService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/UsuarioService.java
@@ -3,6 +3,7 @@ package com.jhonatan.ecommerce_api.service;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioRequestDTO;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioResponseDTO;
 import com.jhonatan.ecommerce_api.dto.usuario.UsuarioUpdateDTO;
+import com.jhonatan.ecommerce_api.enums.TipoUsuario;
 import com.jhonatan.ecommerce_api.exception.EmailAlreadyExistsException;
 import com.jhonatan.ecommerce_api.exception.UsuarioNotFoundException;
 import com.jhonatan.ecommerce_api.mapper.UsuarioMapper;
@@ -11,7 +12,6 @@ import com.jhonatan.ecommerce_api.repository.UsuarioRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.token.TokenService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -59,11 +59,9 @@ public class UsuarioService {
     public UsuarioResponseDTO updateUser(Long id, UsuarioUpdateDTO dto) {
         Usuario usuario = usuarioRepository.findByIdAndAtivoTrue(id)
                 .orElseThrow(() -> new UsuarioNotFoundException("Usuário não encontrado."));
-
         if(usuarioRepository.existsByEmailAndIdNot(dto.email(), id)){
             throw new EmailAlreadyExistsException("Email já está cadastrado!");
         }
-
         usuarioMapper.updateEntity(dto, usuario);
         return usuarioMapper.toDTO(usuario);
     }
@@ -76,6 +74,15 @@ public class UsuarioService {
 
     public Page<UsuarioResponseDTO> listUsers(Pageable pageable) {
         return usuarioRepository.findByAtivoTrue(pageable).map(usuarioMapper::toDTO);
+    }
+
+    @Transactional
+    public UsuarioResponseDTO alterarTipo(Long id, TipoUsuario novoTipo) {
+        Usuario usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new UsuarioNotFoundException("Usuário não encontrado."));
+        usuario.alterarTipo(novoTipo);
+        usuario = usuarioRepository.save(usuario);
+        return usuarioMapper.toDTO(usuario);
     }
 
 


### PR DESCRIPTION
O cadastro público (POST /usuarios) e o update de perfil próprio
(PUT /usuarios/{id}) deixavam o cliente escolher o próprio tipo
(CLIENTE, VENDEDOR, ADMIN) direto no corpo da requisição. Qualquer
pessoa podia se cadastrar como admin só mudando esse campo no JSON.

Removido o campo tipo dos dois DTOs. O cadastro agora sempre cria
CLIENTE. Promoção de tipo virou um endpoint próprio, só acessível
por admin: PATCH /usuarios/{id}/tipo.

Também achei que faltava @EnableMethodSecurity na configuração de
segurança  sem isso, os @PreAuthorize que já existiam no projeto
não tinham efeito nenhum.

Corrigi um bug de timezone no cálculo de expiração do
JWT: o token nascia com validade cerca de 3h menor que o esperado,
por causa de uma conversão errada de fuso horário.

Testado manualmente: admin conseguindo promover outro usuário,
usuário comum sendo bloqueado com 403 ao tentar o mesmo.