### PR TITLE
feat: adiciona soft delete em produtos e categorias

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/controller/CategoriaController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/CategoriaController.java
@@ -11,19 +11,20 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/categorias")
 public class CategoriaController {
+
     private final CategoriaService categoriaService;
     public CategoriaController(CategoriaService categoriaService) {
         this.categoriaService = categoriaService;
     }
 
-    @GetMapping
-    public ResponseEntity<Page<CategoriaResponseDTO>> listCategories( @PageableDefault(size = 10, sort = "nome") Pageable pageable){
 
+    @GetMapping
+    public ResponseEntity<Page<CategoriaResponseDTO>> listCategories(
+            @PageableDefault(size = 10, sort = "nome") Pageable pageable){
         return ResponseEntity.ok(categoriaService.listarCategorias(pageable));
     }
 
@@ -46,11 +47,17 @@ public class CategoriaController {
         return ResponseEntity.ok(categoria);
     }
 
-//    @DeleteMapping("/{id}")
-//    public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
-//        categoriaService.deleteCategoria(id);
-//        return ResponseEntity.noContent().build();
-//    }
+    @PatchMapping("/{id}/activate")
+    public ResponseEntity<Void> activate(@PathVariable Long id) {
+        categoriaService.activate(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/deactivate")
+    public ResponseEntity<Void> deactivate(@PathVariable Long id) {
+        categoriaService.deactivate(id);
+        return ResponseEntity.noContent().build();
+    }
 
 
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/controller/ProdutoController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/ProdutoController.java
@@ -47,4 +47,17 @@ public class ProdutoController {
         return ResponseEntity.ok(produto);
     }
 
+    @PatchMapping("/{id}/activate")
+    public ResponseEntity<Void> activar(@PathVariable Long id){
+        produtoService.activate(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/deactivate")
+    public ResponseEntity<Void> deactivate(@PathVariable Long id){
+        produtoService.deactivate(id);
+        return ResponseEntity.noContent().build();
+    }
+
+
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/categoria/CategoriaResponseDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/categoria/CategoriaResponseDTO.java
@@ -3,7 +3,8 @@ package com.jhonatan.ecommerce_api.dto.categoria;
 public record CategoriaResponseDTO(
         Long id,
         String nome,
-        String descricao
+        String descricao,
+        Boolean ativo
 ) {
 
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/produto/ProdutoResponseDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/produto/ProdutoResponseDTO.java
@@ -10,6 +10,7 @@ public record ProdutoResponseDTO(
         String descricao,
         BigDecimal preco,
         Integer estoque,
+        Boolean ativo,
         CategoriaResponseDTO categoria
 ) {
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/mapper/CategoriaMapper.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/mapper/CategoriaMapper.java
@@ -19,7 +19,8 @@ public class CategoriaMapper {
         return new CategoriaResponseDTO(
                 categoria.getId(),
                 categoria.getNome(),
-                categoria.getDescricao()
+                categoria.getDescricao(),
+                categoria.isAtivo()
         );
     }
 

--- a/src/main/java/com/jhonatan/ecommerce_api/mapper/ProdutoMapper.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/mapper/ProdutoMapper.java
@@ -32,6 +32,7 @@ public class ProdutoMapper {
                 produto.getDescricao(),
                 produto.getPreco(),
                 produto.getEstoque(),
+                produto.isAtivo(),
                 categoriaMapper.toDTO(produto.getCategoria())
         );
     }

--- a/src/main/java/com/jhonatan/ecommerce_api/model/Categoria.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/Categoria.java
@@ -28,11 +28,22 @@ public class Categoria {
     @OneToMany(mappedBy = "categoria", fetch = FetchType.LAZY)
     private List<Produto> produtos = new ArrayList<>();
 
+    @Column(nullable = false)
+    private boolean ativo;
 
     public Categoria(String nome, String descricao) {
         validarNome(nome);
         this.nome = nome;
         this.descricao = descricao;
+        this.ativo = true;
+    }
+
+    public void ativar() {
+        this.ativo = true;
+    }
+
+    public void inativar() {
+        this.ativo = false;
     }
 
     public void alterarNome(String novoNome) {

--- a/src/main/java/com/jhonatan/ecommerce_api/model/Produto.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/Produto.java
@@ -33,6 +33,9 @@ public class Produto {
     @JoinColumn(name = "categoria_id", nullable = false)
     private Categoria categoria;
 
+    @Column(nullable = false)
+    private boolean ativo;
+
     // Controle de concorrência: evita que dois pedidos vendam a mesma
     // unidade em estoque ao mesmo tempo. O Hibernate cuida sozinho.
     @Version
@@ -49,6 +52,15 @@ public class Produto {
         this.preco = preco;
         this.estoque = estoque;
         this.categoria = categoria;
+        this.ativo = true;
+    }
+
+    public void ativar() {
+        this.ativo = true;
+    }
+
+    public void inativar() {
+        this.ativo = false;
     }
 
 

--- a/src/main/java/com/jhonatan/ecommerce_api/repository/CategoriaRepository.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/repository/CategoriaRepository.java
@@ -1,11 +1,17 @@
 package com.jhonatan.ecommerce_api.repository;
 
 import com.jhonatan.ecommerce_api.model.Categoria;
-import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface CategoriaRepository extends JpaRepository<Categoria, Long> {
     boolean existsByNome(String nome);
 
     boolean existsByNomeAndIdNot(String nome, Long id);
+
+    Page<Categoria> findByAtivoTrue(Pageable pageable);
+    Optional<Categoria> findByIdAndAtivoTrue(Long id);
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/repository/ProdutoRepository.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/repository/ProdutoRepository.java
@@ -1,7 +1,13 @@
 package com.jhonatan.ecommerce_api.repository;
 
 import com.jhonatan.ecommerce_api.model.Produto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProdutoRepository extends JpaRepository<Produto, Long> {
+    Page<Produto> findByAtivoTrue(Pageable pageable);
+    Optional<Produto> findByIdAndAtivoTrue(Long id);
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -54,13 +54,17 @@ public class SecurityConfigurations {
                         // 4. ADMIN ou VENDEDOR — gestão de catálogo
                         .requestMatchers(HttpMethod.POST, "/api/v1/produtos").hasAnyRole("ADMIN", "VENDEDOR")
                         .requestMatchers(HttpMethod.PUT, "/api/v1/produtos/**").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/produtos/*/activate").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/produtos/*/deactivate").hasAnyRole("ADMIN", "VENDEDOR")
                         .requestMatchers(HttpMethod.POST, "/api/v1/categorias").hasAnyRole("ADMIN", "VENDEDOR")
                         .requestMatchers(HttpMethod.PUT, "/api/v1/categorias/**").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/categorias/*/activate").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/categorias/*/deactivate").hasAnyRole("ADMIN", "VENDEDOR")
 
                         // 5. ADMIN ou VENDEDOR — gestão de pedido
                         .requestMatchers(HttpMethod.GET, "/api/v1/pedidos").hasAnyRole("ADMIN", "VENDEDOR")
 
-                        // 6. Fallback — qualquer coisa não listada acima exige login
+                        // 6. Qualquer coisa não listada acima exige login
                         .anyRequest().authenticated()
                 ).addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/jhonatan/ecommerce_api/service/CategoriaService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/CategoriaService.java
@@ -7,12 +7,11 @@ import com.jhonatan.ecommerce_api.exception.IdCategoriaNotFoundException;
 import com.jhonatan.ecommerce_api.mapper.CategoriaMapper;
 import com.jhonatan.ecommerce_api.model.Categoria;
 import com.jhonatan.ecommerce_api.repository.CategoriaRepository;
-import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 
 @Service
 public class CategoriaService {
@@ -25,12 +24,14 @@ public class CategoriaService {
         this.mapper = mapper;
     }
 
+    @Transactional(readOnly = true)
     public Page<CategoriaResponseDTO> listarCategorias(Pageable pageable) {
-        return categoriaRepository.findAll(pageable).map(mapper::toDTO);
+        return categoriaRepository.findByAtivoTrue(pageable).map(mapper::toDTO);
     }
 
+    @Transactional(readOnly = true)
     public CategoriaResponseDTO buscarCategoriaPorId(Long id) {
-        Categoria categoria = categoriaRepository.findById(id)
+        Categoria categoria = categoriaRepository.findByIdAndAtivoTrue(id)
                 .orElseThrow(() -> new IdCategoriaNotFoundException("Categoria não encontrada."));
         return mapper.toDTO(categoria);
     }
@@ -58,11 +59,19 @@ public class CategoriaService {
         return mapper.toDTO(categoria);
     }
 
-//    public void deleteCategoria(Long id){
-//        Categoria categoria = categoriaRepository.findById(id)
-//                .orElseThrow(()-> new IdCategoriaNotFoundException("Categoria não encontrada."));
-//        categoriaRepository.delete(categoria);
-//    }
+    @Transactional
+    public void deactivate(Long id){
+        Categoria categoria = categoriaRepository.findById(id)
+                .orElseThrow(() -> new IdCategoriaNotFoundException("Categoria não encontrada!"));
+        categoria.inativar();
+    }
+
+   @Transactional
+    public void activate(Long id) {
+        Categoria categoria = categoriaRepository.findById(id)
+                .orElseThrow(() -> new IdCategoriaNotFoundException("Categoria não encontrada!"));
+        categoria.ativar();
+    }
 
 
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/service/ProdutoService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/ProdutoService.java
@@ -39,12 +39,13 @@ public class ProdutoService {
 
     @Transactional(readOnly = true)
     public Page<ProdutoResponseDTO> listarProdutos(Pageable pageable) {
-        return produtoRepository.findAll(pageable)
+        return produtoRepository.findByAtivoTrue(pageable)
                 .map(produtoMapper::toDTO);
     }
+
     @Transactional(readOnly = true)
     public ProdutoResponseDTO buscarProdutoPorId(Long id){
-         Produto produto = produtoRepository.findById(id)
+         Produto produto = produtoRepository.findByIdAndAtivoTrue(id)
                 .orElseThrow(()-> new IdProdutoNotFoundException("Produto não encontrado."));
          return produtoMapper.toDTO(produto);
     }
@@ -60,6 +61,22 @@ public class ProdutoService {
         produtoMapper.updateEntity(dto, produto, categoriaProduto);
         return produtoMapper.toDTO(produto);
     }
+
+    @Transactional
+    public void activate(Long id) {
+        Produto produto = produtoRepository.findById(id)
+                .orElseThrow(() -> new IdProdutoNotFoundException("Produto não encontrado."));
+        produto.ativar();
+    }
+
+    @Transactional
+    public void deactivate(Long id) {
+        Produto produto = produtoRepository.findById(id)
+                .orElseThrow(() -> new IdProdutoNotFoundException("Produto não encontrado."));
+        produto.inativar();
+    }
+
+
 //    @Transactional
 //    public void deleteProduto(Long id){
 //        produtoRepository.deleteById(id);

--- a/src/main/java/com/jhonatan/ecommerce_api/service/RefreshTokenService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/RefreshTokenService.java
@@ -36,22 +36,17 @@ public class RefreshTokenService {
     public TokenResponseDTO refresh(String refreshTokenValue) {
         RefreshToken tokenAtual = refreshTokenRepository.findByToken(refreshTokenValue)
                 .orElseThrow(() -> new TokenInvalidoException("Refresh token inválido ou inexistente."));
-
         if (tokenAtual.isRevogado()) {
             throw new TokenInvalidoException("Refresh token revogado. Faça login novamente.");
         }
         if (tokenAtual.isExpired()) {
             throw new TokenInvalidoException("Refresh token expirado. Faça login novamente.");
         }
-
         Usuario usuario = tokenAtual.getUsuario();
-
         tokenAtual.revogar();
         refreshTokenRepository.save(tokenAtual);
-
         RefreshToken novoRefreshToken = refreshTokenRepository.save(new RefreshToken(usuario));
         String novoAccessToken = jwtService.generateToken(usuario);
-
         return new TokenResponseDTO(novoAccessToken, novoRefreshToken.getToken());
     }
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/service/UsuarioService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/UsuarioService.java
@@ -20,13 +20,11 @@ import org.springframework.stereotype.Service;
 public class UsuarioService {
     private final UsuarioRepository usuarioRepository;
     private final UsuarioMapper usuarioMapper;
-    private final PasswordEncoder passwordEncoder;
     private final ContaConfirmacaoService contaConfirmacaoService;
 
-    public UsuarioService(UsuarioRepository usuarioRepository, UsuarioMapper usuarioMapper, PasswordEncoder passwordEncoder, ContaConfirmacaoService contaConfirmacaoService) {
+    public UsuarioService(UsuarioRepository usuarioRepository, UsuarioMapper usuarioMapper, ContaConfirmacaoService contaConfirmacaoService) {
         this.usuarioRepository = usuarioRepository;
         this.usuarioMapper = usuarioMapper;
-        this.passwordEncoder = passwordEncoder;
         this.contaConfirmacaoService = contaConfirmacaoService;
     }
 

--- a/src/main/resources/db/migration/V10__add_ativo_to_produtos_e_categorias.sql
+++ b/src/main/resources/db/migration/V10__add_ativo_to_produtos_e_categorias.sql
@@ -1,0 +1,5 @@
+ALTER TABLE produtos
+    ADD COLUMN ativo boolean NOT NULL DEFAULT true;
+
+ALTER TABLE categorias
+    ADD COLUMN ativo boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
## O que mudou

Implementa exclusão lógica (soft delete) para `Produto` e `Categoria`, seguindo
o mesmo padrão já usado em `Usuario`.

- Nova coluna `ativo` (boolean, default `true`) em `produtos` e `categorias`
- `Produto`/`Categoria` ganham `ativar()`/`inativar()`
- Listagem (`GET`) e busca por id passam a retornar apenas registros ativos
- Novos endpoints:
  - `PATCH /api/v1/produtos/{id}/activate`
  - `PATCH /api/v1/produtos/{id}/deactivate`
  - `PATCH /api/v1/categorias/{id}/activate`
  - `PATCH /api/v1/categorias/{id}/deactivate`
- Endpoints restritos a `ADMIN` e `VENDEDOR`
- `CategoriaResponseDTO` passa a expor `ativo`, para exibição em telas de gestão

## Como testar

1. Criar um produto e uma categoria.
2. Executar `PATCH /{id}/deactivate` e confirmar que o registro deixa de aparecer na listagem (`GET`) e na busca por ID.
3. Executar `PATCH /{id}/activate` e confirmar que o registro volta a aparecer.
4. Validar os quatro novos endpoints com um usuário `ADMIN` e `VENDEDOR` (deve retornar sucesso).
5. Validar os quatro novos endpoints com um usuário `CLIENTE` (deve retornar `403 Forbidden`).
6. Confirmar que os endpoints de listagem e busca por ID retornam apenas registros ativos.

## Testes realizados

- ✅ Fluxo completo de ativação e desativação de `Produto`
- ✅ Fluxo completo de ativação e desativação de `Categoria`
- ✅ Validação de permissões para `ADMIN`, `VENDEDOR` e `CLIENTE`
- ✅ Validação da filtragem de registros ativos em listagem e busca por ID