### PR TITLE
feat: adiciona documentação utilizando  Swagger/OpenAPI e handler de …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jhonatan/ecommerce_api/config/OpenApiConfig.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/config/OpenApiConfig.java
@@ -1,0 +1,35 @@
+package com.jhonatan.ecommerce_api.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI ecommerceApiOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Ecommerce API")
+                        .description("API REST para gerenciamento de um e-commerce — usuários, catálogo de produtos/categorias e pedidos.")
+                        .version("v1")
+                        .contact(new Contact()
+                                .name("Jhonatan")
+                                .url("https://github.com/jhonatan-deev/ecommerce_api")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/exception/handler/GlobalExceptionHandler.java
@@ -83,12 +83,12 @@ public class GlobalExceptionHandler {
     // Última rede de segurança: captura qualquer exceção não tratada
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDTO> handleGeneralException(Exception ex) {
+        ex.printStackTrace(); // temporário, só pra diagnosticar agora
         ErrorResponseDTO error = new ErrorResponseDTO(
                 HttpStatus.INTERNAL_SERVER_ERROR.value(),
                 "Erro interno do servidor",
                 LocalDateTime.now()
         );
-
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
     }
 
@@ -117,6 +117,17 @@ public class GlobalExceptionHandler {
         ErrorResponseDTO error = new ErrorResponseDTO(
                 HttpStatus.BAD_REQUEST.value(),
                 ex.getMessage(),
+                LocalDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler(org.springframework.data.core.PropertyReferenceException.class)
+    public ResponseEntity<ErrorResponseDTO> handlePropertyReferenceException(
+            org.springframework.data.core.PropertyReferenceException ex) {
+        ErrorResponseDTO error = new ErrorResponseDTO(
+                HttpStatus.BAD_REQUEST.value(),
+                "Campo de ordenação inválido: " + ex.getPropertyName(),
                 LocalDateTime.now()
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -39,7 +39,10 @@ public class SecurityConfigurations {
                                 "/api/v1/auth/esqueci-senha",
                                 "/api/v1/auth/confirmar-conta",
                                 "/api/v1/auth/reenviar-confirmacao",
-                                "/api/v1/auth/refresh").permitAll()
+                                "/api/v1/auth/refresh",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
 
                         // 2. Público — vitrine (catálogo)
                         .requestMatchers(HttpMethod.GET, "/api/v1/produtos", "/api/v1/produtos/**").permitAll()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,3 +29,5 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
 app.frontend.url=http://localhost:4200
+
+springdoc.override-with-generic-response=false


### PR DESCRIPTION
## O que mudou

- Adicionei o SpringDoc/OpenAPI para documentar a API.
- Configurei o Swagger para aceitar autenticação via JWT (Bearer).
- Liberei `/swagger-ui/**` e `/v3/api-docs/**` na configuração de segurança.
- Adicionei `springdoc.override-with-generic-response=false` para corrigir uma incompatibilidade com o Spring Framework 7.
- Criei um tratamento para `PropertyReferenceException`, então quando o `sort` for inválido a API retorna `400` em vez de `500`.

## Como testar

1. Subir a aplicação.
2. Acessar `http://localhost:8080/swagger-ui/index.html`.
3. Fazer login, copiar o `accessToken` e clicar em **Authorize**.
4. Testar um endpoint autenticado pelo Swagger.
5. Testar `GET /api/v1/produtos?sort=campo_invalido` e verificar se retorna `400`.