### PR TITLE
test: adiciona conteúdo completo dos testes (commit anterior estava v…

### DIFF
--- a/src/test/java/com/jhonatan/ecommerce_api/service/PedidoServiceAtualizarStatusTest.java
+++ b/src/test/java/com/jhonatan/ecommerce_api/service/PedidoServiceAtualizarStatusTest.java
@@ -1,4 +1,185 @@
 package com.jhonatan.ecommerce_api.service;
 
-public class PedidoServiceAtualizarStatusTest {
+import com.jhonatan.ecommerce_api.dto.pedido.PedidoResponseDTO;
+import com.jhonatan.ecommerce_api.enums.StatusPedido;
+import com.jhonatan.ecommerce_api.enums.TipoUsuario;
+import com.jhonatan.ecommerce_api.exception.IdPedidoNotFoundException;
+import com.jhonatan.ecommerce_api.exception.PedidoStatusInvalidoException;
+import com.jhonatan.ecommerce_api.exception.RegraDeNegocioException;
+import com.jhonatan.ecommerce_api.mapper.PedidoMapper;
+import com.jhonatan.ecommerce_api.model.Categoria;
+import com.jhonatan.ecommerce_api.model.ItemPedido;
+import com.jhonatan.ecommerce_api.model.Pedido;
+import com.jhonatan.ecommerce_api.model.Produto;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import com.jhonatan.ecommerce_api.repository.PedidoRepository;
+import com.jhonatan.ecommerce_api.repository.ProdutoRepository;
+import com.jhonatan.ecommerce_api.validation.ValidadorCriacaoPedido;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class PedidoServiceAtualizarStatusTest {
+
+    private PedidoService pedidoService;
+
+    @Mock
+    private PedidoRepository pedidoRepository;
+    @Mock
+    private ProdutoRepository produtoRepository;
+    @Mock
+    private PedidoMapper pedidoMapper;
+    @Mock
+    private ValidadorCriacaoPedido validador;
+
+    private Usuario dono;
+    private Usuario admin;
+    private Usuario outroUsuario;
+    private Produto produto;
+    private Pedido pedido;
+
+    @BeforeEach
+    void setUp() {
+        pedidoService = new PedidoService(
+                pedidoRepository,
+                produtoRepository,
+                pedidoMapper,
+                List.of(validador)
+        );
+
+        dono = new Usuario("Cliente Dono", "dono@teste.com", "senha123", TipoUsuario.CLIENTE);
+        admin = new Usuario("Admin", "admin@teste.com", "senha123", TipoUsuario.ADMIN);
+        outroUsuario = new Usuario("Outro Cliente", "outro@teste.com", "senha123", TipoUsuario.CLIENTE);
+
+        ReflectionTestUtils.setField(dono, "id", 1L);
+        ReflectionTestUtils.setField(admin, "id", 2L);
+        ReflectionTestUtils.setField(outroUsuario, "id", 3L);
+
+        Categoria categoria = new Categoria("Eletrônicos", "Produtos eletrônicos em geral");
+        produto = new Produto("Mouse Gamer", "Mouse com sensor óptico",
+                new BigDecimal("150.00"), 8, categoria); // já com 2 unidades "vendidas" (10 - 2)
+
+        pedido = new Pedido(dono);
+        pedido.adicionarItem(new ItemPedido(produto, 2, produto.getPreco()));
+        // pedido nasce com status PENDENTE (regra do construtor de Pedido)
+    }
+
+    @Test
+    void adminDeveConseguirAvancarStatusParaQualquerTransicaoValida() {
+        //ARRANGE
+        BDDMockito.given(pedidoRepository.findById(1L)).willReturn(Optional.of(pedido));
+        BDDMockito.given(pedidoMapper.toDTO(pedido)).willReturn(
+                new PedidoResponseDTO(1L, null, null, StatusPedido.AGUARDANDO_PAGAMENTO, null, null)
+        );
+
+        //ACT
+        PedidoResponseDTO resultado = pedidoService.atualizarStatus(1L, StatusPedido.AGUARDANDO_PAGAMENTO, admin);
+
+        //ASSERT
+        Assertions.assertEquals(StatusPedido.AGUARDANDO_PAGAMENTO, resultado.statusDePagamento());
+        Assertions.assertEquals(StatusPedido.AGUARDANDO_PAGAMENTO, pedido.getStatusPedido());
+    }
+
+    @Test
+    void donoDevePoderCancelarOProprioPedidoIndependenteDoStatusEnviado() {
+        //ARRANGE — mesmo se o dono mandar um status diferente, deve virar CANCELADO
+        BDDMockito.given(pedidoRepository.findById(1L)).willReturn(Optional.of(pedido));
+        BDDMockito.given(pedidoMapper.toDTO(pedido)).willReturn(
+                new PedidoResponseDTO(1L, null, null, StatusPedido.CANCELADO, null, null)
+        );
+
+        //ACT
+        pedidoService.atualizarStatus(1L, StatusPedido.ENTREGUE, dono);
+
+        //ASSERT
+        Assertions.assertEquals(StatusPedido.CANCELADO, pedido.getStatusPedido());
+    }
+
+    @Test
+    void deveEstornarEstoqueQuandoPedidoForCancelado() {
+        //ARRANGE
+        BDDMockito.given(pedidoRepository.findById(1L)).willReturn(Optional.of(pedido));
+        BDDMockito.given(pedidoMapper.toDTO(pedido)).willReturn(
+                new PedidoResponseDTO(1L, null, null, StatusPedido.CANCELADO, null, null)
+        );
+
+        //ACT
+        pedidoService.atualizarStatus(1L, StatusPedido.CANCELADO, dono);
+
+        //ASSERT
+        Assertions.assertEquals(10, produto.getEstoque()); // 8 + 2 devolvidos
+        BDDMockito.then(produtoRepository).should().save(produto);
+    }
+
+    @Test
+    void naoDeveEstornarEstoqueQuandoTransicaoNaoForCancelamento() {
+        //ARRANGE
+        BDDMockito.given(pedidoRepository.findById(1L)).willReturn(Optional.of(pedido));
+        BDDMockito.given(pedidoMapper.toDTO(pedido)).willReturn(
+                new PedidoResponseDTO(1L, null, null, StatusPedido.AGUARDANDO_PAGAMENTO, null, null)
+        );
+
+        //ACT
+        pedidoService.atualizarStatus(1L, StatusPedido.AGUARDANDO_PAGAMENTO, admin);
+
+        //ASSERT
+        Assertions.assertEquals(8, produto.getEstoque()); // não deve ter mudado
+        BDDMockito.then(produtoRepository).should(BDDMockito.never()).save(any());
+    }
+
+    @Test
+    void deveLancarRegraDeNegocioExceptionQuandoUsuarioNaoForDonoNemAdmin() {
+        //ARRANGE
+        BDDMockito.given(pedidoRepository.findById(1L)).willReturn(Optional.of(pedido));
+
+        //ACT + ASSERT
+        assertThrows(
+                RegraDeNegocioException.class,
+                () -> pedidoService.atualizarStatus(1L, StatusPedido.CANCELADO, outroUsuario)
+        );
+
+        // status não deve ter sido alterado
+        Assertions.assertEquals(StatusPedido.PENDENTE, pedido.getStatusPedido());
+        BDDMockito.then(produtoRepository).should(BDDMockito.never()).save(any());
+    }
+
+    @Test
+    void deveLancarPedidoStatusInvalidoExceptionQuandoTransicaoForInvalida() {
+        //ARRANGE — PENDENTE não pode ir direto para ENTREGUE
+        BDDMockito.given(pedidoRepository.findById(1L)).willReturn(Optional.of(pedido));
+
+        //ACT + ASSERT
+        assertThrows(
+                PedidoStatusInvalidoException.class,
+                () -> pedidoService.atualizarStatus(1L, StatusPedido.ENTREGUE, admin)
+        );
+
+        Assertions.assertEquals(StatusPedido.PENDENTE, pedido.getStatusPedido());
+    }
+
+    @Test
+    void deveLancarIdPedidoNotFoundExceptionQuandoPedidoNaoExistir() {
+        //ARRANGE
+        BDDMockito.given(pedidoRepository.findById(99L)).willReturn(Optional.empty());
+
+        //ACT + ASSERT
+        assertThrows(
+                IdPedidoNotFoundException.class,
+                () -> pedidoService.atualizarStatus(99L, StatusPedido.CANCELADO, admin)
+        );
+    }
 }

--- a/src/test/java/com/jhonatan/ecommerce_api/service/PedidoServiceTest.java
+++ b/src/test/java/com/jhonatan/ecommerce_api/service/PedidoServiceTest.java
@@ -1,4 +1,135 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.jhonatan.ecommerce_api.service;
+
+import com.jhonatan.ecommerce_api.dto.pedido.ItemPedidoRequestDTO;
+import com.jhonatan.ecommerce_api.dto.pedido.PedidoRequestDTO;
+import com.jhonatan.ecommerce_api.dto.pedido.PedidoResponseDTO;
+import com.jhonatan.ecommerce_api.enums.TipoUsuario;
+import com.jhonatan.ecommerce_api.exception.IdProdutoNotFoundException;
+import com.jhonatan.ecommerce_api.mapper.PedidoMapper;
+import com.jhonatan.ecommerce_api.model.Categoria;
+import com.jhonatan.ecommerce_api.model.Pedido;
+import com.jhonatan.ecommerce_api.model.Produto;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import com.jhonatan.ecommerce_api.repository.PedidoRepository;
+import com.jhonatan.ecommerce_api.repository.ProdutoRepository;
+import com.jhonatan.ecommerce_api.validation.ValidadorCriacaoPedido;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
 class PedidoServiceTest {
-  
+
+    // PedidoService recebe List<ValidadorCriacaoPedido> no construtor — o
+    // Mockito não resolve esse tipo genérico sozinho via @InjectMocks, então
+    // montamos o service manualmente no setUp(), passando o mock dentro de
+    // uma List.of(...). O resultado é o mesmo objeto que o @InjectMocks
+    // produziria nos demais casos.
+    private PedidoService pedidoService;
+
+    @Mock
+    private PedidoRepository pedidoRepository;
+    @Mock
+    private ProdutoRepository produtoRepository;
+    @Mock
+    private PedidoMapper pedidoMapper;
+    @Mock
+    private ValidadorCriacaoPedido validador;
+
+    private Usuario usuario;
+    private Produto produto;
+
+    @BeforeEach
+    void setUp() {
+        pedidoService = new PedidoService(
+                pedidoRepository,
+                produtoRepository,
+                pedidoMapper,
+                List.of(validador)
+        );
+
+        usuario = new Usuario("Cliente Teste", "cliente@teste.com", "senha123", TipoUsuario.CLIENTE);
+
+        Categoria categoria = new Categoria("Eletrônicos", "Produtos eletrônicos em geral");
+        produto = new Produto("Mouse Gamer", "Mouse com sensor óptico",
+                new BigDecimal("150.00"), 10, categoria);
+    }
+
+    @Test
+    void deveCriarPedidoERetornarPedidoResponseDTOQuandoDadosForemValidos() {
+        //ARRANGE
+        ItemPedidoRequestDTO itemDto = new ItemPedidoRequestDTO(1L, 2);
+        PedidoRequestDTO requestDTO = new PedidoRequestDTO(List.of(itemDto));
+
+        PedidoResponseDTO responseDTO = new PedidoResponseDTO(
+                1L, null, null, null, new BigDecimal("300.00"), null
+        );
+
+        BDDMockito.given(produtoRepository.findById(1L)).willReturn(Optional.of(produto));
+        BDDMockito.given(pedidoRepository.save(any(Pedido.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        BDDMockito.given(pedidoMapper.toDTO(any(Pedido.class))).willReturn(responseDTO);
+
+        //ACT
+        PedidoResponseDTO resultado = pedidoService.criarPedido(requestDTO, usuario);
+
+        //ASSERT
+        Assertions.assertEquals(1L, resultado.id());
+        Assertions.assertEquals(new BigDecimal("300.00"), resultado.valorTotalPedido());
+        Assertions.assertEquals(8, produto.getEstoque()); // 10 - 2
+
+        BDDMockito.then(validador).should().validar(requestDTO);
+        BDDMockito.then(produtoRepository).should().save(produto);
+        BDDMockito.then(pedidoRepository).should().save(any(Pedido.class));
+    }
+
+    @Test
+    void deveLancarIdProdutoNotFoundExceptionQuandoProdutoNaoExistir() {
+        //ARRANGE
+        ItemPedidoRequestDTO itemDto = new ItemPedidoRequestDTO(999L, 1);
+        PedidoRequestDTO requestDTO = new PedidoRequestDTO(List.of(itemDto));
+
+        BDDMockito.given(produtoRepository.findById(999L)).willReturn(Optional.empty());
+
+        //ACT + ASSERT
+        IdProdutoNotFoundException exception = assertThrows(
+                IdProdutoNotFoundException.class,
+                () -> pedidoService.criarPedido(requestDTO, usuario)
+        );
+        Assertions.assertTrue(exception.getMessage().contains("999"));
+
+        BDDMockito.then(validador).should().validar(requestDTO);
+        BDDMockito.then(pedidoRepository).should(BDDMockito.never()).save(any());
+    }
+
+    @Test
+    void deveLancarIllegalStateExceptionQuandoEstoqueForInsuficiente() {
+        //ARRANGE — produto tem 10 em estoque, pedido pede 999
+        ItemPedidoRequestDTO itemDto = new ItemPedidoRequestDTO(1L, 999);
+        PedidoRequestDTO requestDTO = new PedidoRequestDTO(List.of(itemDto));
+
+        BDDMockito.given(produtoRepository.findById(1L)).willReturn(Optional.of(produto));
+
+        //ACT + ASSERT
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> pedidoService.criarPedido(requestDTO, usuario)
+        );
+        Assertions.assertTrue(exception.getMessage().contains("Estoque insuficiente"));
+        Assertions.assertEquals(10, produto.getEstoque()); // não deve ter mudado
+
+        BDDMockito.then(pedidoRepository).should(BDDMockito.never()).save(any());
+    }
 }


### PR DESCRIPTION
Cobre criarPedido (baixa de estoque, produto inexistente, estoque insuficiente) e atualizarStatus (permissões, máquina de estados, estorno de estoque no cancelamento).

Obs: o commit anterior tinha os arquivos de teste vazios por engano corrigido com o conteúdo completo.
