### PR TITLE
Corrige erro de Flyway não executar migrations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
 			<version>4.5.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.flywaydb</groupId>
-			<artifactId>flyway-core</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-flyway</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>


### PR DESCRIPTION
As migrations pararam de rodar depois da atualização pro Spring Boot 4.

O que mudou:
- Troquei a dependência antiga do Flyway (flyway-core) pela nova,
  spring-boot-starter-flyway, que é a exigida a partir dessa versão
  do Spring Boot

Testado localmente e as migrations voltaram a rodar normal.