### PR TITLE
Adiciona Docker Compose para o banco de dados

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: ecommerce_db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ecommerce_db
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - ecommerce_pgdata:/var/lib/postgresql/data
+
+volumes:
+  ecommerce_pgdata:


### PR DESCRIPTION
Agora dá pra subir o Postgres local via Docker, sem precisar instalar
ele direto na máquina.

O que mudou:
- docker-compose.yml com o serviço do Postgres
- Dados do banco ficam salvos entre reinícios (volume)

Como usar:
1. Criar um arquivo .env na raiz com DB_USERNAME e DB_PASSWORD
2. Rodar: docker compose up -d

Testado localmente, aplicação conectou e o Flyway rodou as
migrations sem problema.