### PR TITLE
Feat/autenticacao dois fatores

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/AuthController.java
@@ -1,59 +1,63 @@
 package com.jhonatan.ecommerce_api.controller;
 
-import com.jhonatan.ecommerce_api.dto.login.LoginRequest;
-import com.jhonatan.ecommerce_api.dto.login.ReenviarConfirmacaoDTO;
 import com.jhonatan.ecommerce_api.dto.RefreshRequestDTO;
 import com.jhonatan.ecommerce_api.dto.TokenResponseDTO;
+import com.jhonatan.ecommerce_api.dto.dois_fatores.AtivarDoisFatoresDTO;
+import com.jhonatan.ecommerce_api.dto.dois_fatores.DesativarDoisFatoresDTO;
+import com.jhonatan.ecommerce_api.dto.dois_fatores.GerarDoisFatoresResponseDTO;
+import com.jhonatan.ecommerce_api.dto.dois_fatores.VerificarDoisFatoresDTO;
+import com.jhonatan.ecommerce_api.dto.login.LoginRequest;
+import com.jhonatan.ecommerce_api.dto.login.LoginResponseDTO;
+import com.jhonatan.ecommerce_api.dto.login.ReenviarConfirmacaoDTO;
 import com.jhonatan.ecommerce_api.dto.senha.NovaSenhaRequestDTO;
 import com.jhonatan.ecommerce_api.dto.senha.SolicitarRecuperacaoSenhaDTO;
-import com.jhonatan.ecommerce_api.model.RefreshToken;
 import com.jhonatan.ecommerce_api.model.Usuario;
 import com.jhonatan.ecommerce_api.security.JwtService;
 import com.jhonatan.ecommerce_api.service.ContaConfirmacaoService;
+import com.jhonatan.ecommerce_api.service.DoisFatoresService;
 import com.jhonatan.ecommerce_api.service.RefreshTokenService;
 import com.jhonatan.ecommerce_api.service.ResetaSenhaService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
     private final AuthenticationManager authenticationManager;
-    private final JwtService tokenService;
     private final ContaConfirmacaoService contaConfirmacaoService;
     private final ResetaSenhaService resetaSenhaService;
     private final RefreshTokenService refreshTokenService;
+    private final DoisFatoresService doisFatoresService;
 
-    public AuthController(AuthenticationManager authenticationManager, JwtService tokenService,
+    public AuthController(AuthenticationManager authenticationManager,
                           ContaConfirmacaoService contaConfirmacaoService, ResetaSenhaService resetaSenhaService,
-                          RefreshTokenService refreshTokenService) {
+                          RefreshTokenService refreshTokenService, DoisFatoresService doisFatoresService) {
         this.authenticationManager = authenticationManager;
-        this.tokenService = tokenService;
         this.contaConfirmacaoService = contaConfirmacaoService;
         this.resetaSenhaService = resetaSenhaService;
         this.refreshTokenService = refreshTokenService;
+        this.doisFatoresService = doisFatoresService;
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponseDTO> efetuarLogin(@RequestBody @Valid LoginRequest loginRequest) {
+    public ResponseEntity<LoginResponseDTO> efetuarLogin(@RequestBody @Valid LoginRequest loginRequest) {
         var autenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.senha());
         var authentication = authenticationManager.authenticate(autenticationToken);
         var usuario = (Usuario) authentication.getPrincipal();
-        String accessToken = tokenService.generateToken(usuario);
-        RefreshToken refreshToken = refreshTokenService.gerarNovoToken(usuario);
-        return ResponseEntity.ok(new TokenResponseDTO(accessToken, refreshToken.getToken()));
+        return ResponseEntity.ok(doisFatoresService.finalizarLogin(usuario));
     }
 
-
     @GetMapping("/confirmar-conta")
-    public ResponseEntity<String> efetuarConta(@RequestParam String token) {
+    public ResponseEntity<String> confirmarConta(@RequestParam String token) {
         contaConfirmacaoService.confirmarConta(token);
         return ResponseEntity.ok("Conta confirmada com sucesso! Você já pode fazer login.");
     }
-
 
     @PostMapping("/esqueci-senha")
     public ResponseEntity<String> solicitarResetSenha(@RequestBody @Valid SolicitarRecuperacaoSenhaDTO dto) {
@@ -77,4 +81,29 @@ public class AuthController {
     public ResponseEntity<TokenResponseDTO> renovarToken(@RequestBody @Valid RefreshRequestDTO dto) {
         return ResponseEntity.ok(refreshTokenService.refresh(dto.refreshToken()));
     }
+
+    @PostMapping("/2fa/gerar")
+    public ResponseEntity<GerarDoisFatoresResponseDTO> gerarDoisFatores(@AuthenticationPrincipal Usuario usuario) {
+        return ResponseEntity.ok(doisFatoresService.iniciarAtivacao(usuario));
+    }
+
+    @PostMapping("/2fa/verificar")
+    public ResponseEntity<LoginResponseDTO> verificarDoisFatores(@RequestBody @Valid VerificarDoisFatoresDTO dto) {
+        return ResponseEntity.ok(doisFatoresService.verificarLogin(dto));
+    }
+
+    @PostMapping("/2fa/ativar")
+    public ResponseEntity<List<String>> ativarDoisFatores(@AuthenticationPrincipal Usuario usuario,
+                                                          @RequestBody @Valid AtivarDoisFatoresDTO dto) {
+        return ResponseEntity.ok(doisFatoresService.confirmarAtivacao(usuario, dto));
+    }
+
+    @PostMapping("/2fa/desativar")
+    public ResponseEntity<Void> desativarDoisFatores(@AuthenticationPrincipal Usuario usuario,
+                                                     @RequestBody @Valid DesativarDoisFatoresDTO dto) {
+        doisFatoresService.desativar(usuario, dto);
+        return ResponseEntity.noContent().build();
+    }
+
+
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/AtivarDoisFatoresDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/AtivarDoisFatoresDTO.java
@@ -1,0 +1,10 @@
+package com.jhonatan.ecommerce_api.dto.dois_fatores;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AtivarDoisFatoresDTO(
+        @NotBlank
+        String setupToken,
+        @NotBlank
+        String codigo) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/DesativarDoisFatoresDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/DesativarDoisFatoresDTO.java
@@ -1,0 +1,9 @@
+package com.jhonatan.ecommerce_api.dto.dois_fatores;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DesativarDoisFatoresDTO(
+        @NotBlank
+        String senhaAtual
+) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/GerarDoisFatoresResponseDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/GerarDoisFatoresResponseDTO.java
@@ -1,0 +1,7 @@
+package com.jhonatan.ecommerce_api.dto.dois_fatores;
+
+public record GerarDoisFatoresResponseDTO(
+        String qrCodeBase64,
+        String setupToken
+) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/VerificarDoisFatoresDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/dois_fatores/VerificarDoisFatoresDTO.java
@@ -1,0 +1,10 @@
+package com.jhonatan.ecommerce_api.dto.dois_fatores;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record VerificarDoisFatoresDTO(
+        @NotBlank
+        String tempToken,
+        @NotBlank
+        String codigo) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/login/LoginResponseDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/login/LoginResponseDTO.java
@@ -1,0 +1,14 @@
+package com.jhonatan.ecommerce_api.dto.login;
+
+public record LoginResponseDTO(
+        boolean requiresTwoFactor,
+        String tempToken,
+        String accessToken,
+        String refreshToken) {
+    public static LoginResponseDTO pendente(String tempToken) {
+        return new LoginResponseDTO(true, tempToken, null, null);
+    }
+    public static LoginResponseDTO completo(String accessToken, String refreshToken) {
+        return new LoginResponseDTO(false, null, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/exception/CodigoInvalidoException.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/exception/CodigoInvalidoException.java
@@ -1,0 +1,7 @@
+package com.jhonatan.ecommerce_api.exception;
+
+public class CodigoInvalidoException extends RuntimeException {
+    public CodigoInvalidoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/exception/SenhaInvalidaException.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/exception/SenhaInvalidaException.java
@@ -1,0 +1,7 @@
+package com.jhonatan.ecommerce_api.exception;
+
+public class SenhaInvalidaException extends RuntimeException {
+    public SenhaInvalidaException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/exception/handler/GlobalExceptionHandler.java
@@ -48,7 +48,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({
             PedidoStatusInvalidoException.class,
-            TokenInvalidoException.class
+            TokenInvalidoException.class,
+            CodigoInvalidoException.class,
+            SenhaInvalidaException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleBadRequestException(RuntimeException ex) {
         ErrorResponseDTO error = new ErrorResponseDTO(

--- a/src/main/java/com/jhonatan/ecommerce_api/model/CodigoBackup2FA.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/CodigoBackup2FA.java
@@ -1,0 +1,42 @@
+package com.jhonatan.ecommerce_api.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Entity
+@Table(name = "codigos_backup_2fa")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CodigoBackup2FA {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(name = "codigo_hash", nullable = false)
+    private String codigoHash;
+
+    @Column(nullable = false)
+    private boolean usado;
+
+    public CodigoBackup2FA(Usuario usuario, String codigoHash) {
+        this.usuario = usuario;
+        this.codigoHash = codigoHash;
+        this.usado = false;
+    }
+
+    public boolean corresponde(String codigoDigitado, PasswordEncoder encoder) {
+        return !usado && encoder.matches(codigoDigitado, codigoHash);
+    }
+
+    public void marcarComoUsado() {
+        this.usado = true;
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/model/Usuario.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/Usuario.java
@@ -39,6 +39,12 @@ public class Usuario implements UserDetails {
     @Column(nullable = false)
     private boolean ativo;
 
+    @Column(nullable = false)
+    private boolean doisFatoresAtivo;
+
+    @Column(name = "dois_fatores_segredo")
+    private String doisFatoresSegredo;
+
     public Usuario(String nome, String email, String senha, TipoUsuario tipo) {
         validarNome(nome);
         validarEmail(email);
@@ -105,6 +111,24 @@ public class Usuario implements UserDetails {
         if (tipo == null) {
             throw new IllegalArgumentException("Tipo de usuário é obrigatório.");
         }
+    }
+
+    public void ativarDoisFatores(String segredo) {
+        this.doisFatoresSegredo = segredo;
+        this.doisFatoresAtivo = true;
+    }
+
+    public void desativarDoisFatores() {
+        this.doisFatoresSegredo = null;
+        this.doisFatoresAtivo = false;
+    }
+
+    public boolean isDoisFatoresAtivo() {
+        return doisFatoresAtivo;
+    }
+
+    public String getDoisFatoresSegredo() {
+        return doisFatoresSegredo;
     }
 
     @Override

--- a/src/main/java/com/jhonatan/ecommerce_api/repository/CodigoBackup2FARepository.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/repository/CodigoBackup2FARepository.java
@@ -1,0 +1,12 @@
+package com.jhonatan.ecommerce_api.repository;
+
+import com.jhonatan.ecommerce_api.model.CodigoBackup2FA;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CodigoBackup2FARepository extends JpaRepository<CodigoBackup2FA, Long> {
+    List<CodigoBackup2FA> findByUsuarioAndUsadoFalse(Usuario usuario);
+    void deleteByUsuario(Usuario usuario); // usado ao gerar um novo lote
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/JwtService.java
@@ -4,14 +4,14 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.jhonatan.ecommerce_api.exception.EmailNotFoundException;
 import com.jhonatan.ecommerce_api.model.Usuario;
+import com.jhonatan.ecommerce_api.repository.UsuarioRepository;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
 @Service
@@ -21,6 +21,12 @@ public class JwtService {
     private String secret;
     @Value("${api.security.token.issuer}")
     private String secreteIssuer;
+
+    private final UsuarioRepository usuarioRepository;
+
+    public JwtService(UsuarioRepository usuarioRepository) {
+        this.usuarioRepository = usuarioRepository;
+    }
 
 
     @PostConstruct
@@ -59,11 +65,56 @@ public class JwtService {
     }
 
 
-//    private Instant dataExpiracao() {
-//        return LocalDateTime.now().plusDays(1).toInstant(ZoneOffset.UTC);
-//    }
-
     private Instant dataExpiracao() {
         return Instant.now().plus(60, ChronoUnit.MINUTES);
     }
+
+    // 2FA
+
+    //Autenticação de dois fatores metodos - 2fa
+    // setup token: nasce em /2fa/gerar, morre em /2fa/ativar — carrega o segredo pendente, assinado
+    public String generateSetupToken(Usuario usuario, String segredo) {
+        Algorithm algorithm = Algorithm.HMAC256(secret);
+        return JWT.create()
+                .withIssuer(secreteIssuer)
+                .withSubject(usuario.getEmail())
+                .withClaim("tipo", "2fa_setup")
+                .withClaim("segredo", segredo)
+                .withExpiresAt(Instant.now().plus(10, ChronoUnit.MINUTES))
+                .sign(algorithm);
+    }
+
+    public String getSegredoDoSetupToken(String token, String emailEsperado) {
+        Algorithm algorithm = Algorithm.HMAC256(secret);
+        var decoded = JWT.require(algorithm)
+                .withIssuer(secreteIssuer)
+                .withClaim("tipo", "2fa_setup")
+                .withSubject(emailEsperado) // garante que o setupToken pertence ao mesmo usuário logado
+                .build()
+                .verify(token);
+        return decoded.getClaim("segredo").asString();
+    }
+
+    // temp token: nasce em /login (quando 2FA está ativo), morre em /2fa/verificar
+    public String generateTempToken(Usuario usuario) {
+        Algorithm algorithm = Algorithm.HMAC256(secret);
+        return JWT.create()
+                .withIssuer(secreteIssuer)
+                .withSubject(usuario.getEmail())
+                .withClaim("tipo", "2fa_pendente")
+                .withExpiresAt(Instant.now().plus(5, ChronoUnit.MINUTES))
+                .sign(algorithm);
+    }
+
+    public Usuario validarTempTokenERetornarUsuario(String token) {
+        Algorithm algorithm = Algorithm.HMAC256(secret);
+        var decoded = JWT.require(algorithm)
+                .withIssuer(secreteIssuer)
+                .withClaim("tipo", "2fa_pendente")  // rejeita token de acesso normal aqui
+                .build()
+                .verify(token);
+        return usuarioRepository.findByEmailIgnoreCase(decoded.getSubject())
+                .orElseThrow(() -> new EmailNotFoundException("Usuário não encontrado"));
+    }
+
 }

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -38,6 +38,7 @@ public class SecurityConfigurations {
 
                         .requestMatchers(
                                 "/api/v1/auth/login",
+                                "/api/v1/auth/2fa/verificar",
                                 "/api/v1/auth/resetar-senha",
                                 "/api/v1/auth/esqueci-senha",
                                 "/api/v1/auth/confirmar-conta",
@@ -48,7 +49,7 @@ public class SecurityConfigurations {
                                 "/swagger-ui.html",
                                 "/oauth2/**",
                                 "/login/oauth2/**"
-                                ).permitAll()
+                        ).permitAll()
 
                         // 2. Público — vitrine (catálogo)
                         .requestMatchers(HttpMethod.GET, "/api/v1/produtos", "/api/v1/produtos/**").permitAll()

--- a/src/main/java/com/jhonatan/ecommerce_api/service/CodigoBackupService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/CodigoBackupService.java
@@ -1,0 +1,59 @@
+package com.jhonatan.ecommerce_api.service;
+
+import com.jhonatan.ecommerce_api.model.CodigoBackup2FA;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import com.jhonatan.ecommerce_api.repository.CodigoBackup2FARepository;
+import jakarta.transaction.Transactional;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class CodigoBackupService {
+
+    private static final int QUANTIDADE_CODIGOS = 8;
+
+    private final CodigoBackup2FARepository repository;
+    private final PasswordEncoder passwordEncoder;
+
+    public CodigoBackupService(CodigoBackup2FARepository repository, PasswordEncoder passwordEncoder) {
+        this.repository = repository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    // Chamado quando o usuário confirma a ativação do 2FA.
+    // Gera um lote novo de códigos de uso único, apagando qualquer lote anterior.
+    @Transactional
+    public List<String> gerarCodigosParaUsuario(Usuario usuario) {
+        repository.deleteByUsuario(usuario);
+        List<String> codigosEmTextoPuro = new ArrayList<>();
+        for (int i = 0; i < QUANTIDADE_CODIGOS; i++) {
+            String codigo = gerarCodigoAleatorio();
+            repository.save(new CodigoBackup2FA(usuario, passwordEncoder.encode(codigo)));
+            codigosEmTextoPuro.add(codigo);
+        }
+        return codigosEmTextoPuro; // única vez que existem em texto puro
+    }
+
+    // Chamado no /2fa/verificar como alternativa ao código TOTP,
+    // caso o usuário tenha perdido acesso ao app autenticador.
+    @Transactional
+    public boolean validarEConsumir(Usuario usuario, String codigoDigitado) {
+        return repository.findByUsuarioAndUsadoFalse(usuario).stream()
+                .filter(codigo -> codigo.corresponde(codigoDigitado, passwordEncoder))
+                .findFirst()
+                .map(codigo -> {
+                    codigo.marcarComoUsado();
+                    repository.save(codigo);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    private String gerarCodigoAleatorio() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/service/DoisFatoresService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/DoisFatoresService.java
@@ -1,0 +1,130 @@
+package com.jhonatan.ecommerce_api.service;
+
+import com.jhonatan.ecommerce_api.dto.dois_fatores.AtivarDoisFatoresDTO;
+import com.jhonatan.ecommerce_api.dto.dois_fatores.DesativarDoisFatoresDTO;
+import com.jhonatan.ecommerce_api.dto.dois_fatores.GerarDoisFatoresResponseDTO;
+import com.jhonatan.ecommerce_api.dto.dois_fatores.VerificarDoisFatoresDTO;
+import com.jhonatan.ecommerce_api.dto.login.LoginResponseDTO;
+import com.jhonatan.ecommerce_api.exception.CodigoInvalidoException;
+import com.jhonatan.ecommerce_api.exception.SenhaInvalidaException;
+import com.jhonatan.ecommerce_api.model.RefreshToken;
+import com.jhonatan.ecommerce_api.model.Usuario;
+import com.jhonatan.ecommerce_api.repository.UsuarioRepository;
+import com.jhonatan.ecommerce_api.security.JwtService;
+import dev.samstevens.totp.code.CodeVerifier;
+import dev.samstevens.totp.code.DefaultCodeGenerator;
+import dev.samstevens.totp.code.DefaultCodeVerifier;
+import dev.samstevens.totp.code.HashingAlgorithm;
+import dev.samstevens.totp.exceptions.QrGenerationException;
+import dev.samstevens.totp.qr.QrData;
+import dev.samstevens.totp.qr.QrGenerator;
+import dev.samstevens.totp.qr.ZxingPngQrGenerator;
+import dev.samstevens.totp.secret.DefaultSecretGenerator;
+import dev.samstevens.totp.secret.SecretGenerator;
+import dev.samstevens.totp.time.SystemTimeProvider;
+import jakarta.transaction.Transactional;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+import java.util.List;
+
+@Service
+public class DoisFatoresService {
+
+    private final SecretGenerator secretGenerator = new DefaultSecretGenerator();
+    private final QrGenerator qrGenerator = new ZxingPngQrGenerator();
+    private final CodeVerifier codeVerifier = new DefaultCodeVerifier(
+            new DefaultCodeGenerator(), new SystemTimeProvider());
+
+    private final UsuarioRepository usuarioRepository;
+    private final JwtService tokenService;
+    private final CodigoBackupService codigoBackupService;
+    private final RefreshTokenService refreshTokenService;
+    private final PasswordEncoder passwordEncoder;
+
+    public DoisFatoresService(UsuarioRepository usuarioRepository, JwtService tokenService,
+                              CodigoBackupService codigoBackupService, RefreshTokenService refreshTokenService,
+                              PasswordEncoder passwordEncoder) {
+        this.usuarioRepository = usuarioRepository;
+        this.tokenService = tokenService;
+        this.codigoBackupService = codigoBackupService;
+        this.refreshTokenService = refreshTokenService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    // Chamado por POST /2fa/gerar — usuário já logado pedindo pra ativar o 2FA.
+    // Ainda não salva nada no banco: o segredo viaja assinado dentro do setupToken
+    // e só vira permanente se o usuário confirmar com o código certo em confirmarAtivacao().
+    public GerarDoisFatoresResponseDTO iniciarAtivacao(Usuario usuario) {
+        String segredo = secretGenerator.generate();
+        String qrCodeBase64 = gerarQrCodeBase64(usuario.getEmail(), segredo);
+        String setupToken = tokenService.generateSetupToken(usuario, segredo);
+        return new GerarDoisFatoresResponseDTO(qrCodeBase64, setupToken);
+    }
+
+    // Chamado por POST /2fa/ativar — usuário confirma com o código do app autenticador.
+    // Só aqui o 2FA é de fato marcado como ativo, e os códigos de backup são gerados.
+    @Transactional
+    public List<String> confirmarAtivacao(Usuario usuario, AtivarDoisFatoresDTO dto) {
+        String segredoPendente = tokenService.getSegredoDoSetupToken(dto.setupToken(), usuario.getEmail());
+        if (!codeVerifier.isValidCode(segredoPendente, dto.codigo())) {
+            throw new CodigoInvalidoException("Código incorreto. Tente novamente.");
+        }
+        usuario.ativarDoisFatores(segredoPendente);
+        usuarioRepository.save(usuario);
+        return codigoBackupService.gerarCodigosParaUsuario(usuario);
+    }
+
+    // Chamado por POST /2fa/desativar — exige a senha atual como confirmação.
+    public void desativar(Usuario usuario, DesativarDoisFatoresDTO dto) {
+        if (!passwordEncoder.matches(dto.senhaAtual(), usuario.getPassword())) {
+            throw new SenhaInvalidaException("Senha incorreta.");
+        }
+        usuario.desativarDoisFatores();
+        usuarioRepository.save(usuario);
+    }
+
+    // Chamado por POST /login, depois que email+senha já foram validados pelo AuthenticationManager.
+    // Decide se devolve os tokens completos direto, ou se pede o segundo fator primeiro.
+    public LoginResponseDTO finalizarLogin(Usuario usuario) {
+        if (usuario.isDoisFatoresAtivo()) {
+            return LoginResponseDTO.pendente(tokenService.generateTempToken(usuario));
+        }
+        return gerarTokensDeAcesso(usuario);
+    }
+
+    // Chamado por POST /2fa/verificar — segunda etapa do login quando 2FA está ativo.
+    // Aceita tanto o código TOTP do app quanto um código de backup.
+    public LoginResponseDTO verificarLogin(VerificarDoisFatoresDTO dto) {
+        Usuario usuario = tokenService.validarTempTokenERetornarUsuario(dto.tempToken());
+        boolean codigoValido = codeVerifier.isValidCode(usuario.getDoisFatoresSegredo(), dto.codigo())
+                || codigoBackupService.validarEConsumir(usuario, dto.codigo());
+        if (!codigoValido) {
+            throw new CodigoInvalidoException("Código inválido ou expirado.");
+        }
+        return gerarTokensDeAcesso(usuario);
+    }
+
+    private LoginResponseDTO gerarTokensDeAcesso(Usuario usuario) {
+        String accessToken = tokenService.generateToken(usuario);
+        RefreshToken refreshToken = refreshTokenService.gerarNovoToken(usuario);
+        return LoginResponseDTO.completo(accessToken, refreshToken.getToken());
+    }
+
+    private String gerarQrCodeBase64(String email, String segredo) {
+        QrData data = new QrData.Builder()
+                .label(email)
+                .secret(segredo)
+                .issuer("EcommerceAPI")
+                .algorithm(HashingAlgorithm.SHA1)
+                .digits(6)
+                .period(30)
+                .build();
+        try {
+            return Base64.getEncoder().encodeToString(qrGenerator.generate(data));
+        } catch (QrGenerationException e) {
+            throw new RuntimeException("Erro ao gerar QR Code", e);
+        }
+    }
+}

--- a/src/main/resources/db/migration/V12__add_2fa_to_usuarios.sql
+++ b/src/main/resources/db/migration/V12__add_2fa_to_usuarios.sql
@@ -1,0 +1,3 @@
+ALTER TABLE usuarios
+    ADD COLUMN dois_fatores_ativo BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN dois_fatores_segredo VARCHAR(255);

--- a/src/main/resources/db/migration/V13__create_table_codigos_backup_2fa.sql
+++ b/src/main/resources/db/migration/V13__create_table_codigos_backup_2fa.sql
@@ -1,0 +1,7 @@
+CREATE TABLE codigos_backup_2fa (
+        id BIGSERIAL PRIMARY KEY,
+        usuario_id BIGINT NOT NULL REFERENCES usuarios(id),
+        codigo_hash VARCHAR(255) NOT NULL,
+        usado BOOLEAN NOT NULL DEFAULT FALSE,
+        criado_em TIMESTAMP NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Adiciona autenticação de dois fatores (2FA)

2FA opcional (o usuário ativa quando quiser, não vem ligado por padrão),
usando TOTP o mesmo esquema do Google Authenticator/Authy. Inclui
códigos de backup pra quem perder o celular.

### O que mudou
- Login normal continua igual quando o 2FA está desligado
- Com 2FA ligado, o login pede um código extra antes de liberar o acesso
- Endpoints novos pra ativar, confirmar e desativar o 2FA

### Como testar
1. Login normal funciona igual antes
2. Ativa o 2FA, escaneia o QR Code, confirma com o código do app
3. Loga de novo: agora pede o código
4. Testa também um código de backup no lugar do TOTP
5. Desativa o 2FA com a senha