### PR TITLE
feat: CRUD de banners com vínculo opcional a categoria

### DIFF
--- a/src/main/java/com/jhonatan/ecommerce_api/controller/BannerController.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/controller/BannerController.java
@@ -1,0 +1,48 @@
+package com.jhonatan.ecommerce_api.controller;
+
+import com.jhonatan.ecommerce_api.dto.banner.BannerRequestDTO;
+import com.jhonatan.ecommerce_api.dto.banner.BannerResponseDTO;
+import com.jhonatan.ecommerce_api.service.BannerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/banners")
+@RequiredArgsConstructor
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    public List<BannerResponseDTO> listar() {
+        return bannerService.listarAtivos();
+    }
+
+    @PostMapping
+    public ResponseEntity<BannerResponseDTO> create(@RequestBody @Valid BannerRequestDTO request) {
+        BannerResponseDTO response = bannerService.criar(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<BannerResponseDTO> update(@PathVariable Long id, @RequestBody @Valid BannerRequestDTO request) {
+        return ResponseEntity.ok(bannerService.atualizar(id, request));
+    }
+
+    @PatchMapping("/{id}/activate")
+    public ResponseEntity<Void> activate(@PathVariable Long id) {
+        bannerService.ativar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/deactivate")
+    public ResponseEntity<Void> deactivate(@PathVariable Long id) {
+        bannerService.inativar(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/banner/BannerRequestDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/banner/BannerRequestDTO.java
@@ -1,0 +1,15 @@
+package com.jhonatan.ecommerce_api.dto.banner;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record BannerRequestDTO(
+        @NotBlank String titulo,
+        @NotBlank String imagemUrl,
+        @NotNull
+        @PositiveOrZero
+        Integer ordem,
+        Long categoriaId
+) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/dto/banner/BannerResponseDTO.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/dto/banner/BannerResponseDTO.java
@@ -1,0 +1,12 @@
+package com.jhonatan.ecommerce_api.dto.banner;
+
+public record BannerResponseDTO(
+        Long id,
+        String titulo,
+        String imagemUrl,
+        Integer ordem,
+        boolean ativo,
+        Long categoriaId,
+        String categoriaNome
+) {
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/mapper/BannerMapper.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/mapper/BannerMapper.java
@@ -1,0 +1,21 @@
+package com.jhonatan.ecommerce_api.mapper;
+
+import com.jhonatan.ecommerce_api.dto.banner.BannerResponseDTO;
+import com.jhonatan.ecommerce_api.model.Banner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BannerMapper {
+
+    public BannerResponseDTO toResponse(Banner banner) {
+        return new BannerResponseDTO(
+                banner.getId(),
+                banner.getTitulo(),
+                banner.getImagemUrl(),
+                banner.getOrdem(),
+                banner.isAtivo(),
+                banner.getCategoria() != null ? banner.getCategoria().getId() : null,
+                banner.getCategoria() != null ? banner.getCategoria().getNome() : null
+        );
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/model/Banner.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/model/Banner.java
@@ -1,0 +1,93 @@
+package com.jhonatan.ecommerce_api.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "banners")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Banner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String titulo;
+
+    @Column(name = "imagem_url", nullable = false, length = 500)
+    private String imagemUrl;
+
+    @Column(nullable = false)
+    private Integer ordem;
+
+    @Column(nullable = false)
+    private boolean ativo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "categoria_id")
+    private Categoria categoria;
+
+    public Banner(String titulo, String imagemUrl, Integer ordem, Categoria categoria) {
+        validarTitulo(titulo);
+        validarImagemUrl(imagemUrl);
+        validarOrdem(ordem);
+        this.titulo = titulo;
+        this.imagemUrl = imagemUrl;
+        this.ordem = ordem;
+        this.categoria = categoria;
+        this.ativo = true;
+    }
+
+    public void ativar() {
+        this.ativo = true;
+    }
+
+    public void inativar() {
+        this.ativo = false;
+    }
+
+    public void alterarTitulo(String novoTitulo) {
+        validarTitulo(novoTitulo);
+        this.titulo = novoTitulo;
+    }
+
+    public void alterarImagemUrl(String novaImagemUrl) {
+        validarImagemUrl(novaImagemUrl);
+        this.imagemUrl = novaImagemUrl;
+    }
+
+    public void alterarOrdem(Integer novaOrdem) {
+        validarOrdem(novaOrdem);
+        this.ordem = novaOrdem;
+    }
+
+    public void vincularCategoria(Categoria categoria) {
+        this.categoria = categoria;
+    }
+
+    public void desvincularCategoria() {
+        this.categoria = null;
+    }
+
+    private void validarTitulo(String titulo) {
+        if (titulo == null || titulo.isBlank()) {
+            throw new IllegalArgumentException("Título do banner não pode ser nulo ou vazio.");
+        }
+    }
+
+    private void validarImagemUrl(String imagemUrl) {
+        if (imagemUrl == null || imagemUrl.isBlank()) {
+            throw new IllegalArgumentException("URL da imagem não pode ser nula ou vazia.");
+        }
+    }
+
+    private void validarOrdem(Integer ordem) {
+        if (ordem == null || ordem < 0) {
+            throw new IllegalArgumentException("Ordem do banner deve ser um número não negativo.");
+        }
+    }
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/repository/BannerRepository.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/repository/BannerRepository.java
@@ -1,0 +1,10 @@
+package com.jhonatan.ecommerce_api.repository;
+
+import com.jhonatan.ecommerce_api.model.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+    List<Banner> findByAtivoTrueOrderByOrdemAsc();
+}

--- a/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/security/SecurityConfigurations.java
@@ -54,6 +54,7 @@ public class SecurityConfigurations {
                         // 2. Público — vitrine (catálogo)
                         .requestMatchers(HttpMethod.GET, "/api/v1/produtos", "/api/v1/produtos/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/categorias", "/api/v1/categorias/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/banners", "/api/v1/banners/**").permitAll()
 
                         // 3. Só ADMIN
                         .requestMatchers(HttpMethod.GET, "/api/v1/usuarios").hasRole("ADMIN")
@@ -70,6 +71,10 @@ public class SecurityConfigurations {
                         .requestMatchers(HttpMethod.PUT, "/api/v1/categorias/**").hasAnyRole("ADMIN", "VENDEDOR")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/categorias/*/activate").hasAnyRole("ADMIN", "VENDEDOR")
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/categorias/*/deactivate").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/banners").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/banners/**").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/banners/*/activate").hasAnyRole("ADMIN", "VENDEDOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/banners/*/deactivate").hasAnyRole("ADMIN", "VENDEDOR")
 
                         // 5. ADMIN ou VENDEDOR — gestão de pedido
                         .requestMatchers(HttpMethod.GET, "/api/v1/pedidos").hasAnyRole("ADMIN", "VENDEDOR")

--- a/src/main/java/com/jhonatan/ecommerce_api/service/BannerService.java
+++ b/src/main/java/com/jhonatan/ecommerce_api/service/BannerService.java
@@ -1,0 +1,79 @@
+package com.jhonatan.ecommerce_api.service;
+
+import com.jhonatan.ecommerce_api.dto.banner.BannerRequestDTO;
+import com.jhonatan.ecommerce_api.dto.banner.BannerResponseDTO;
+import com.jhonatan.ecommerce_api.mapper.BannerMapper;
+import com.jhonatan.ecommerce_api.model.Banner;
+import com.jhonatan.ecommerce_api.model.Categoria;
+import com.jhonatan.ecommerce_api.repository.BannerRepository;
+import com.jhonatan.ecommerce_api.repository.CategoriaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+    private final CategoriaRepository categoriaRepository;
+    private final BannerMapper bannerMapper;
+
+    @Transactional(readOnly = true)
+    public List<BannerResponseDTO> listarAtivos() {
+        return bannerRepository.findByAtivoTrueOrderByOrdemAsc()
+                .stream()
+                .map(bannerMapper::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public BannerResponseDTO criar(BannerRequestDTO request) {
+        Categoria categoria = buscarCategoriaOpcional(request.categoriaId());
+        Banner banner = new Banner(request.titulo(), request.imagemUrl(), request.ordem(), categoria);
+        return bannerMapper.toResponse(bannerRepository.save(banner));
+    }
+
+    @Transactional
+    public BannerResponseDTO atualizar(Long id, BannerRequestDTO request) {
+        Banner banner = buscarPorId(id);
+        banner.alterarTitulo(request.titulo());
+        banner.alterarImagemUrl(request.imagemUrl());
+        banner.alterarOrdem(request.ordem());
+
+        Categoria categoria = buscarCategoriaOpcional(request.categoriaId());
+        if (categoria != null) {
+            banner.vincularCategoria(categoria);
+        } else {
+            banner.desvincularCategoria();
+        }
+
+        return bannerMapper.toResponse(banner);
+    }
+
+    @Transactional
+    public void ativar(Long id) {
+        buscarPorId(id).ativar();
+    }
+
+    @Transactional
+    public void inativar(Long id) {
+        buscarPorId(id).inativar();
+    }
+
+    private Banner buscarPorId(Long id) {
+        return bannerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Banner não encontrado com id: " + id));
+    }
+
+    private Categoria buscarCategoriaOpcional(Long categoriaId) {
+        if (categoriaId == null) {
+            return null;
+        }
+        return categoriaRepository.findById(categoriaId)
+                .orElseThrow(() -> new EntityNotFoundException("Categoria não encontrada com id: " + categoriaId));
+    }
+}

--- a/src/main/resources/db/migration/V14__create_banners_table.sql
+++ b/src/main/resources/db/migration/V14__create_banners_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE banners
+(
+    id           bigserial primary key,
+    titulo       varchar(150) not null,
+    imagem_url   varchar(500) not null,
+    ordem        integer      not null default 0,
+    ativo        boolean      not null default true,
+    categoria_id bigint references categorias (id)
+);


### PR DESCRIPTION
## Descrição

Nova entidade Banner, com vínculo opcional a Categoria, para suportar cadastro de banners promocionais no catálogo.

O que foi feito

- Entidade Banner
- CRUD completo via /api/v1/banners (listar, criar, atualizar, ativar, inativar).
- Migration V14 criando a tabela banners, com categoria_id como FK opcional.
- Regras de acesso: leitura pública, escrita restrita a ADMIN/VENDEDOR

Como testar

1. Aplicar a migration e subir a aplicação.
2. GET /api/v1/banners — público, retorna os banners ativos.
3. POST /api/v1/banners como ADMIN/VENDEDOR — testar com e sem categoriaId, para confirmar que o vínculo é de fato opcional.
4. PATCH /{id}/deactivate — banner deixa de aparecer no GET.
